### PR TITLE
Fix preset category filtering

### DIFF
--- a/js/override.js
+++ b/js/override.js
@@ -44,6 +44,7 @@
       state.activePackKey = safeFn("loadLS", () => null)("wm_active_pack", null);
       state.presetForceFamily = safeFn("loadLS", () => null)("wm_preset_force_family", null);
       state.presetLimitComplexity = safeFn("loadLS", () => false)("wm_preset_limit_complexity", false);
+      state.presetCategory = safeFn("loadLS", () => null)("wm_preset_category", null);
 
       // Track whether Advanced panel is open (IA ticket)
       state.advOpen = safeFn("loadLS", () => false)("wm_adv_open", false);
@@ -108,7 +109,7 @@
     safeFn("saveLS", () => {})("wm_active_pack", state.activePackKey);
 
     // Set source scope if the preset specifies CSV sources
-       state.sourceScope = Array.isArray(p.sourceScope)
+    state.sourceScope = Array.isArray(p.sourceScope)
       ? p.sourceScope.map(safeNormalizeSourcePath)
       : [];
     safeFn("saveLS", () => {})("wm_source_scope", state.sourceScope);
@@ -120,6 +121,10 @@
     // Set forced family (pack-level) if provided
     state.presetForceFamily = p.forceFamily || null;
     safeFn("saveLS", () => {})("wm_preset_force_family", state.presetForceFamily);
+
+    // Set category (pack-level) if provided
+    state.presetCategory = p.category || null;
+    safeFn("saveLS", () => {})("wm_preset_category", state.presetCategory);
 
     // Complexity limitation for certain presets
     state.presetLimitComplexity = !!p.limitComplexity;
@@ -160,6 +165,7 @@
       (Array.isArray(state.presetTriggers) && state.presetTriggers.length) ||
       (Array.isArray(state.sourceScope) && state.sourceScope.length) ||
       !!state.presetForceFamily ||
+      !!state.presetCategory ||
       !!state.presetLimitComplexity;
 
     if (!hasAnything) return;
@@ -170,6 +176,7 @@
     state.sourceScope = [];
     state.presetForceFamily = null;
     state.presetLimitComplexity = false;
+    state.presetCategory = null;
 
     safeFn("saveLS", () => {})("wm_active_preset", state.activePreset);
     safeFn("saveLS", () => {})("wm_active_pack", state.activePackKey);
@@ -177,6 +184,7 @@
     safeFn("saveLS", () => {})("wm_source_scope", state.sourceScope);
     safeFn("saveLS", () => {})("wm_preset_force_family", state.presetForceFamily);
     safeFn("saveLS", () => {})("wm_preset_limit_complexity", state.presetLimitComplexity);
+    safeFn("saveLS", () => {})("wm_preset_category", state.presetCategory);
 
     if (typeof refreshFilterPills === "function") {
       try {
@@ -211,13 +219,18 @@
 
     // Pack-level: restrict by CSV sources if provided
     if (Array.isArray(state.sourceScope) && state.sourceScope.length) {
-    const scope = new Set(state.sourceScope.map(safeNormalizeSourcePath));
+      const scope = new Set(state.sourceScope.map(safeNormalizeSourcePath));
       list = list.filter((r) => scope.has(safeNormalizeSourcePath(r.Source)));
     }
 
     // Pack-level: restrict by forced family
     if (state.presetForceFamily) {
       list = list.filter((r) => r.RuleFamily === state.presetForceFamily);
+    }
+
+    // Pack-level: restrict by preset category
+    if (state.presetCategory) {
+      list = list.filter((r) => r.RuleCategory === state.presetCategory);
     }
 
     // Pack-level: restrict by preset triggers
@@ -639,4 +652,3 @@
     document.addEventListener("DOMContentLoaded", () => setTimeout(init, 0));
   }
 })();
-


### PR DESCRIPTION
### Motivation

- Starter-pack presets were not fully constraining results because pack-level category scope wasn’t being applied, so preset filters didn’t reliably produce the intended focused deck.

### Description

- Persist `presetCategory` in `state` and load/save it to local storage so a preset’s category is tracked like other pack-level restrictions.
- When `applyPreset` runs, store the preset `category` into `state.presetCategory` and persist it via `saveLS` alongside existing pack state.
- When clearing a pack (`clearPresetLayer`), reset and persist `presetCategory` to avoid stale category restrictions.
- Apply `presetCategory` as a pack-level restriction in the two-stage filter pipeline inside `applyFilters` before applying user filters.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710b8803b88324b10fca3b37232a36)