### PR TITLE
Fix preset pack filtering and filter interactions

### DIFF
--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -482,24 +482,21 @@ const PRESET_DEFS = {
     id: "starter-preps",
     titleKey: "starterPrepsTitle",
     descKey: "starterPrepsDesc",
-    category: "Preposition",
-    triggers: ["am","ar","at","gan","i","o","trwy","drwy","tan","dros","tros","heb","hyd","wrth"],
+    triggers: [],
     sourceScope: ["data/prep.csv"],
   },
   "numbers-1-10": {
     id: "numbers-1-10",
     titleKey: "numbersTitle",
     descKey: "numbersDesc",
-    category: "Numerals",
-    triggers: ["un","dau","tri","pedwar","pump","chwech","saith","wyth","naw","deg"],
+    triggers: ["un","dau","dwy","tri","tair","pedwar","chwech","chwe","pum","pump","saith","wyth","naw","deg"],
   },
   "articles": {
     id: "articles",
     titleKey: "articlesTitle",
     descKey: "articlesDesc",
     category: "Article",
-    triggers: ["y","yr","'r","r"],
-    limitComplexity: true,
+    triggers: [],
   },
   "place-names": {
     id: "place-names",
@@ -507,7 +504,6 @@ const PRESET_DEFS = {
     descKey: "placeNamesDesc",
     category: "PlaceName",
     triggers: [],
-    forceFamily: "Nasal",
     tipKey: "placeNamesTip",
   },
 };
@@ -777,9 +773,11 @@ function toggleBtn(text, active, onToggle) {
 
   const hasPresetLayer =
     Boolean(state.activePreset) ||
+    Boolean(state.activePackKey) ||
     (Array.isArray(state.presetTriggers) && state.presetTriggers.length) ||
     (Array.isArray(state.sourceScope) && state.sourceScope.length) ||
     Boolean(state.presetForceFamily) ||
+    Boolean(state.presetCategory) ||
     Boolean(state.presetLimitComplexity);
 
   const familyAll = ["Soft","Aspirate","Nasal","None"];
@@ -1877,5 +1875,3 @@ function wireUi() {
   // Apply current language immediately (navbar.js also applies [data-lang] visibility)
   syncLangFromNavbar();
 })();
-
-

--- a/js/override.js
+++ b/js/override.js
@@ -398,7 +398,7 @@
         try { refreshFilterPills(); } catch (_) {}
       }
 
-      // ---- Rebind core filter buttons so they do NOT clear the active preset
+      // ---- Rebind core filter buttons to clear any active preset pack
       (function rebindCoreFilters() {
         const allFamilies = ["Soft", "Aspirate", "Nasal", "None"];
         const allOutcomes = ["SM", "AM", "NM", "NONE"];
@@ -410,7 +410,23 @@
           }
         };
 
+        function clearPackIfNeeded() {
+          const hasPreset =
+            !!state.activePreset ||
+            !!state.activePackKey ||
+            (Array.isArray(state.presetTriggers) && state.presetTriggers.length) ||
+            (Array.isArray(state.sourceScope) && state.sourceScope.length) ||
+            !!state.presetForceFamily ||
+            !!state.presetCategory ||
+            !!state.presetLimitComplexity;
+
+          if (hasPreset) {
+            window.clearPresetLayer();
+          }
+        }
+
         function rerun() {
+          clearPackIfNeeded();
           window.applyFilters();
           if (typeof rebuildDeck === "function") rebuildDeck();
           safeRefreshPills();


### PR DESCRIPTION
### Motivation
- Preset packs should act as a separate pack-level scope (source/category/trigger constraints) while keeping core/advanced filters working across all CSV sources when used. 
- The UI must clearly indicate when a preset pack is active and avoid highlighting core/advanced category pills while a pack is constraining the deck.

### Description
- Adjust `PRESET_DEFS` in `js/mutation-trainer.js` to: leave `starter-preps` triggers empty and rely on `sourceScope: [

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710f69c35483248feaa2836cd74810)