### PR TITLE
Fix starter prepositions pack source scope

### DIFF
--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -17,7 +17,8 @@ function normalizeSourcePath(s) {
     .toString()
     .trim()
     .replace(/^https?:\/\/[^/]+\/?/i, "")
-    .replace(/^\/+/, "");
+    .replace(/^\/+/, "")
+    .replace(/^data\//i, "");
 }
 // Canonicalise Trigger values for reliable matching (presets + URL params).
 // - lowercases, trims, normalises apostrophes
@@ -483,7 +484,7 @@ const PRESET_DEFS = {
     titleKey: "starterPrepsTitle",
     descKey: "starterPrepsDesc",
     triggers: [],
-    sourceScope: ["data/prep.csv"],
+    sourceScope: ["prep.csv"],
   },
   "numbers-1-10": {
     id: "numbers-1-10",


### PR DESCRIPTION
### Motivation
- Ensure preset filter packs link to the intended CSV source so the "Starter prepositions" pack correctly targets `prep.csv` across environments by normalising source paths.

### Description
- Strip a leading `data/` segment in `normalizeSourcePath()` and update the `starter-preps` preset `sourceScope` from `data/prep.csv` to `prep.csv` so pack-level source scoping matches the stamped `o.Source` values.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697119b11f508324afacaa57c5560988)