### PR TITLE
Refine presets: scope articles to article-sylfaen.csv and adjust number triggers

### DIFF
--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -490,7 +490,7 @@ const PRESET_DEFS = {
     id: "numbers-1-10",
     titleKey: "numbersTitle",
     descKey: "numbersDesc",
-    triggers: ["un","dau","dwy","tri","tair","pedwar","chwech","chwe","pum","pump","saith","wyth","naw","deg"],
+    triggers: ["un","dwy","dau","tri","tair","pedwar","pedair","pum","pump","chwech","chwe","saith","wyth","naw","deg"],
   },
   "articles": {
     id: "articles",
@@ -498,6 +498,7 @@ const PRESET_DEFS = {
     descKey: "articlesDesc",
     category: "Article",
     triggers: [],
+    sourceScope: ["article-sylfaen.csv"],
   },
   "place-names": {
     id: "place-names",


### PR DESCRIPTION
### Motivation
- Restrict the Articles preset to the new `article-sylfaen.csv` source to avoid polluting categories across other datasets, and ensure the Numbers preset covers the expected numeral trigger variants across all CSVs.

### Description
- Updated `js/mutation-trainer.js` `PRESET_DEFS` so `numbers-1-10` uses an adjusted `triggers` array (adds/ reorders variants such as `dwy`, `dau`, `pedair`) and `articles` now includes `sourceScope: ["article-sylfaen.csv"]` while keeping its `category: "Article"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697128eee9488324bc5345fc30ce450a)