### PR TITLE
Wire preset UI toggles, aria state, and filter refresh

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -245,9 +245,10 @@ body{
   box-shadow: 0 14px 26px rgba(15,23,42,0.12);
 }
 
+.preset-btn[aria-pressed="true"],
 .preset-on {
-  border-color: var(--indigo-500);
-  background: var(--indigo-50);
+  border-color: rgba(4, 120, 87, 0.35);
+  background: rgba(4, 120, 87, 0.10);
 }
 
 


### PR DESCRIPTION
### Motivation
- Make preset tiles behave as toggles so clicking an active preset clears the pack-level state while leaving user filters intact.
- Keep the visual / ARIA state for presets in sync so the active preset is obvious and accessible.
- Ensure applying/clearing a preset refreshes filters, pills, deck and the focus indicator so the UI reflects pack-level constraints immediately.

### Description
- Updated `js/mutation-trainer.js` to set `aria-pressed` on preset buttons, add a toggle-style `onclick` handler that clears the preset layer when the active preset is clicked, and call `applyFilters()`, `rebuildDeck()`, `buildFilters()`, `render()`, `refreshFilterPills()` and `updateFocusIndicator()` as appropriate to refresh UI state.
- Changed dynamic preset tile generation to include `aria-pressed` and avoid double-binding by using `dataset._wmPresetBound` and `onclick` rather than repeated `addEventListener` calls.
- Added `aria-pressed` updates in `updatePresetActiveClasses()` so static and dynamic preset buttons remain in sync with `state.activePreset`.
- Updated `css/styles.css` to use an emerald tint for active presets via the selector `.preset-btn[aria-pressed="true"], .preset-on` so the active pack is visibly highlighted (works for GitHub Pages overrides).

### Testing
- Launched a local static server with `python -m http.server 8000` to serve the app and verify assets loaded successfully.
- Ran an automated Playwright script to click a preset and capture a screenshot, but the Chromium instance crashed (`TargetClosedError` / SIGSEGV) so the end-to-end check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712bc07f7c83249483564518140507)