### PR TITLE
Fix preset and pill highlight sync

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -247,8 +247,9 @@ body{
 
 .preset-btn[aria-pressed="true"],
 .preset-on {
-  border-color: rgba(4, 120, 87, 0.35);
-  background: rgba(4, 120, 87, 0.10);
+  border-color: rgba(4, 120, 87, 0.75);
+  background: rgba(16, 185, 129, 0.18);
+  box-shadow: 0 12px 22px rgba(4, 120, 87, 0.12), inset 0 1px 0 rgba(255,255,255,0.75);
 }
 
 

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -722,7 +722,8 @@ function wirePresetUi() {
   $$("[data-preset]").forEach(el => {
     const id = el.getAttribute("data-preset");
     if (!id) return;
-    const isActive = id === state.activePreset;
+    const activeKey = state.activePackKey || state.activePreset;
+    const isActive = id === activeKey;
     el.classList.toggle("preset-on", isActive);
     el.setAttribute("aria-pressed", isActive ? "true" : "false");
   });
@@ -866,22 +867,23 @@ function toggleBtn(text, active, onClick) {
   const familyAll = ["Soft","Aspirate","Nasal","None"];
   const families = state.families?.length ? state.families : familyAll;
   let familyAllActive = families.length === familyAll.length;
-  const familyKeys = hasPresetLayer && familyAllActive ? [] : families;
-  if (hasPresetLayer && familyAllActive) familyAllActive = false;
+  const familyKeys = hasPresetLayer ? [] : families;
+  if (hasPresetLayer) familyAllActive = true;
   applyPillState($("#familyBtns"), familyKeys, familyAllActive);
 
   const outcomeAll = ["SM","AM","NM","NONE"];
   const outcomes = state.outcomes?.length ? state.outcomes : outcomeAll;
   let outcomeAllActive = outcomes.length === outcomeAll.length;
-  const outcomeKeys = hasPresetLayer && outcomeAllActive ? [] : outcomes;
-  if (hasPresetLayer && outcomeAllActive) outcomeAllActive = false;
+  const outcomeKeys = hasPresetLayer ? [] : outcomes;
+  if (hasPresetLayer) outcomeAllActive = true;
   applyPillState($("#outcomeBtns"), outcomeKeys, outcomeAllActive);
 
   const categories = state.categories || [];
   let categoriesAllActive = categories.length === 0;
-  if (hasPresetLayer && categoriesAllActive) categoriesAllActive = false;
-  applyPillState($("#basicCatBtns"), categories, categoriesAllActive);
-  applyPillState($("#catBtns"), categories, categoriesAllActive);
+  if (hasPresetLayer) categoriesAllActive = true;
+  const categoryKeys = hasPresetLayer ? [] : categories;
+  applyPillState($("#basicCatBtns"), categoryKeys, categoriesAllActive);
+  applyPillState($("#catBtns"), categoryKeys, categoriesAllActive);
 }
 function buildFilters() {
   const lang = state.lang || "en";
@@ -931,6 +933,7 @@ function buildFilters() {
 
     // ALL pill
     const allBtn = toggleBtn(label("categories", "All"), isAllFamilies, () => {
+      clearPresetLayer();
       state.families = [...allFamilies];
       saveLS("wm_families", state.families);
       applyFilters();
@@ -945,6 +948,7 @@ function buildFilters() {
     for (const f of ["Soft","Aspirate","Nasal","None"]) {
       const isOn = isAllFamilies || state.families.includes(f);
       const b = toggleBtn(label("rulefamily", f), isOn, () => {
+        clearPresetLayer();
         let fams = Array.isArray(state.families) && state.families.length
           ? [...state.families]
           : [...allFamilies];
@@ -981,6 +985,7 @@ function buildFilters() {
     const allOutcomes = ["SM","AM","NM","NONE"];
 
     const allBtn = toggleBtn(label("categories", "All"), isAllOutcomes, () => {
+      clearPresetLayer();
       state.outcomes = [...allOutcomes];
       saveLS("wm_outcomes", state.outcomes);
       applyFilters();
@@ -995,6 +1000,7 @@ function buildFilters() {
     for (const o of ["SM","AM","NM","NONE"]) {
       const isOn = isAllOutcomes || state.outcomes.includes(o);
       const b = toggleBtn(label("rulefamily", o), isOn, () => {
+        clearPresetLayer();
         let outs = Array.isArray(state.outcomes) && state.outcomes.length
           ? [...state.outcomes]
           : [...allOutcomes];
@@ -1027,6 +1033,7 @@ function buildFilters() {
     const categoriesAllActive = state.categories.length === 0;
 
     const allBtn = toggleBtn(label("categories", "All"), categoriesAllActive, () => {
+      clearPresetLayer();
       state.categories = [];
       saveLS("wm_categories", state.categories);
       applyFilters();
@@ -1041,6 +1048,7 @@ function buildFilters() {
     for (const c of categories) {
       const isOn = categoriesAllActive || state.categories.includes(c);
       const b = toggleBtn(label("categories", c), isOn, () => {
+        clearPresetLayer();
         let cats = Array.isArray(state.categories) ? [...state.categories] : [];
         const noneSelected = cats.length === 0;
         if (noneSelected) {
@@ -1072,6 +1080,7 @@ function buildFilters() {
   if (trigEl) {
     trigEl.value = state.triggerQuery || "";
     trigEl.oninput = () => {
+      clearPresetLayer();
       state.triggerQuery = trigEl.value;
       saveLS("wm_trig", state.triggerQuery);
       applyFilters();
@@ -1086,6 +1095,7 @@ function buildFilters() {
   if (nilEl) {
     nilEl.checked = Boolean(state.nilOnly);
     nilEl.onchange = () => {
+      clearPresetLayer();
       state.nilOnly = Boolean(nilEl.checked);
       saveLS("wm_nil", state.nilOnly);
       applyFilters();


### PR DESCRIPTION
### Motivation
- Ensure preset packs and individual filter "pills" stay visually consistent so selecting a preset shows no specific pill highlighted while still indicating the "All" state.
- Make switching from pills to presets (and vice versa) clear the opposite visual state so the UI never shows conflicting active indicators.
- Use consistent accessible styling on active preset buttons via the `.preset-on` class and `aria-pressed="true"` with an emerald accent.

### Description
- Updated `refreshFilterPills()` in `js/mutation-trainer.js` to treat any active preset layer as a reason to clear pill selections (only the "All" pill remains highlighted) by passing empty `activeKeys` for families/outcomes/categories and adjusting the `allActive` flags accordingly.
- Added `clearPresetLayer()` calls to every core/advanced filter toggle and input handlers (family, outcome, category, trigger, nil-only, and the All buttons) so changing filters programmatically or via UI will deselect the active preset.
- Made preset active detection consistent by using `state.activePackKey || state.activePreset` when toggling `.preset-on` and `aria-pressed` on `[data-preset]` buttons.
- Adjusted preset button styling in `css/styles.css` to use a stronger emerald border/background and subtle shadow for the active state, applied to `.preset-btn[aria-pressed="true"], .preset-on`.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright script that opened `index.html`, clicked the first `[data-preset]` button and captured a screenshot as `artifacts/preset-active.png`, which completed successfully.
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697131090b4883249a784402b373f3f2)