### PR TITLE
Show Card ID in practice view, add top reset buttons, and remove admin tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,11 +110,17 @@
           <!-- Compact stats strip (Ticket 5) -->
           <div id="practiceStats" class="grid grid-cols-2 gap-2 mb-4">
             <div class="rounded-xl border border-slate-200 bg-white p-2">
-              <div id="practiceAccTitle" class="text-[10px] uppercase tracking-wide text-slate-500 mb-0.5">Accuracy</div>
+              <div class="flex items-center justify-between mb-0.5">
+                <div id="practiceAccTitle" class="text-[10px] uppercase tracking-wide text-slate-500">Accuracy</div>
+                <button id="btnResetStatsTop" class="btn btn-ghost px-2 py-1 text-xs" title="Reset stats" type="button">↺</button>
+              </div>
               <div id="practiceAcc" class="text-xl font-semibold">0%</div>
             </div>
             <div class="rounded-xl border border-slate-200 bg-white p-2">
-              <div id="practiceStreakTitle" class="text-[10px] uppercase tracking-wide text-slate-500 mb-0.5">Streak</div>
+              <div class="flex items-center justify-between mb-0.5">
+                <div id="practiceStreakTitle" class="text-[10px] uppercase tracking-wide text-slate-500">Streak</div>
+                <button id="btnResetStreakTop" class="btn btn-ghost px-2 py-1 text-xs" title="Reset streak" type="button">↺</button>
+              </div>
               <div class="text-xl font-semibold"><span id="practiceStreak">0</span> <span aria-hidden="true">🔥</span></div>
             </div>
           </div>
@@ -180,27 +186,6 @@
                   <span id="nilOnlyText">Nil-cases only (no mutation expected)</span>
                 </label>
 
-                <!-- Admin tools relocated into Advanced -->
-                <div id="adminPanel" class="mt-4">
-                  <!-- Provide id for translation of admin section title -->
-                  <div id="adminTitle" class="text-sm font-medium mb-2">Admin tools</div>
-                  <!-- Data URL label -->
-                  <label id="adminDataUrlLabel" class="text-sm font-medium">Data URL </label>
-                  <div class="mt-2 flex gap-2">
-                    <input id="dataUrl" class="w-full border rounded-xl px-3 py-2" placeholder="Paste Google Sheet CSV (Publish → CSV)">
-                    <button id="btnLoadUrl" class="btn btn-primary px-4 py-2">LOAD</button>
-                  </div>
-                    <div class="mt-2 flex flex-wrap gap-2 text-sm">
-                      <button id="btnShareable" class="btn btn-ghost px-3 py-1.5">Shareable link</button>
-                      <button id="btnExportMisses" class="btn btn-ghost px-3 py-1.5">Export misses</button>
-                    </div>
-                    <div class="mt-3">
-                      <!-- Provide id for translation of load local CSV heading -->
-                      <div id="loadCsvTitle" class="text-sm font-medium mb-1">Load local CSV</div>
-                      <input id="fileCsv" type="file" accept=".csv" />
-                    </div>
-                    <hr class="my-4" />
-                </div>
               </div>
             </details>
           </div>


### PR DESCRIPTION
### Motivation
- Make it easy to identify and fix individual cards by surfacing a discrete `CardId` in the practice UI. 
- Reduce clutter by removing rarely-used admin tooling from the UI and code.
- Improve session visibility by adding small reset controls to the compact accuracy and streak panels and keeping deck progress visible.

### Description
- Added a compact `Card ID` label to the practice header using `getCardId(card, idxShown)` and added `cardIdLabel` translations in `LABEL` for both languages. 
- Added top-panel reset buttons `#btnResetStatsTop` and `#btnResetStreakTop` and wired them to clear `state.history` and set `state.streakResetAt` respectively, with translated titles set in `applyLanguage`.
- Kept and rendered the deck progress bar/indicator inside `renderPractice` so remaining cards are visible while practising. 
- Removed admin UI from `index.html` and removed accompanying admin wiring in `js/mutation-trainer.js` (CSV load, shareable link, export misses, and file input handling), including removal of the now-unused `download` helper. 

### Testing
- Launched a local static server with `python -m http.server 8000` and ran a Playwright script that opened `http://127.0.0.1:8000/index.html` and captured a full-page screenshot to verify the updated practice UI rendered; the script completed successfully and produced a screenshot. 
- No unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697136c107a48324a9f17a9a64d72e2f)