### PR TITLE
Refresh bilingual onboarding panel with concise, task-oriented guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,37 +61,72 @@
         <div class="text-sm text-slate-700">
           <!-- EN -->
           <div data-lang="en">
-            <div class="font-medium mb-1">Welcome! How to use this trainer.</div>
-            <ol class="list-decimal ml-5 leading-relaxed">
-              <li>
-                Select a practice mode. <b>Random review</b> presents cards in a truly random order, and you can reshuffle
-                the deck at any time. <b>Smart review</b> adapts to your progress using a spaced-repetition (Leitner)
-                system: cards you get wrong reappear sooner and cards you get right appear less often. Use the toggle at
-                the top of the card to switch modes.
-              </li>
-              <li>Choose a <b>Filter</b> to pick what to practise (Prepositions, Numerals, Possessive, etc.).</li>
-              <li>Read the sentence and type the correct form in the box.</li>
-              <li>Press <b>Check</b> to mark your answer.</li>
-              <li>Read the <b>Why</b> explanation, then click <b>Next</b>.</li>
-            </ol>
+            <div class="font-medium mb-2">Welcome! Get the most out of the trainer.</div>
+            <div class="space-y-3 leading-relaxed">
+              <div>
+                <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">1. Pick a focus fast</div>
+                <p>
+                  Start with a <b>Quick pack</b> (Start here) for a guided set, or build your own focus with <b>Core filters</b>.
+                  Use <b>More filters</b> to add trigger searches (e.g. <i>i</i>, <i>o</i>, <i>y</i>) or nil-cases only.
+                </p>
+              </div>
+              <div>
+                <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">2. Choose how cards repeat</div>
+                <p>
+                  Use the card toggle to switch modes. <b>Random</b> shuffles the deck; <b>Smart</b> uses spaced repetition,
+                  bringing back mistakes sooner and letting mastered cards fade.
+                </p>
+              </div>
+              <div>
+                <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">3. Answer + learn quickly</div>
+                <p>
+                  Type the correct mutation, then hit <b>Check</b>. Use <b>Hint</b> or <b>Reveal</b> when you’re stuck, and
+                  <b>Skip</b> to move on. Read the <b>Why</b> explanation, then <b>Next</b>.
+                </p>
+              </div>
+              <div>
+                <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">4. Listen and track progress</div>
+                <p>
+                  Tap <b>Hear</b> to listen, and open <b>More stats</b> for accuracy, streaks, mastery by outcome/category,
+                  and deck progress.
+                </p>
+              </div>
+            </div>
           </div>
 
           <!-- CY -->
           <div data-lang="cy">
-            <div class="font-medium mb-1">Croeso! Sut i ddefnyddio’r hyfforddwr.</div>
-            <ol class="list-decimal ml-5 leading-relaxed">
-              <li>
-                Dewiswch fodd ymarfer. Mae <b>Adolygu ar hap</b> yn dangos cardiau mewn trefn ar hap go iawn, ac mae modd
-                ailgymysgu’r pecyn unrhyw bryd. Mae <b>Adolygu clyfar</b> yn addasu i’ch cynnydd gan ddefnyddio system
-                ailadrodd bylchog (Leitner): bydd cardiau rydych chi’n eu cael yn anghywir yn dod yn ôl yn gynt, a bydd
-                cardiau rydych chi’n eu cael yn gywir yn dod yn ôl yn llai aml. Defnyddiwch y toglo ar frig y cerdyn i
-                newid modd.
-              </li>
-              <li>Dewiswch <b>Hidlydd</b> i benderfynu beth i’w ymarfer (Arddodiaid, Rhifau, Meddiannol, ac ati).</li>
-              <li>Darllenwch y frawddeg a theipiwch y ffurf gywir yn y blwch.</li>
-              <li>Pwyswch <b>Gwirio</b> i farcio’ch ateb.</li>
-              <li>Darllenwch yr esboniad <b>Pam</b>, yna cliciwch <b>Nesaf</b>.</li>
-            </ol>
+            <div class="font-medium mb-2">Croeso! Manteisiwch ar yr hyfforddwr.</div>
+            <div class="space-y-3 leading-relaxed">
+              <div>
+                <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">1. Dewiswch ffocws yn gyflym</div>
+                <p>
+                  Dechreuwch gyda <b>Pecyn cyflym</b> (Dechreuwch yma), neu adeiladwch ffocws gyda’r <b>Hidlyddion craidd</b>.
+                  Defnyddiwch <b>Mwy o hidlyddion</b> i chwilio am sbardunau (e.e. <i>i</i>, <i>o</i>, <i>y</i>) neu achosion dim-treiglad yn unig.
+                </p>
+              </div>
+              <div>
+                <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">2. Dewiswch sut mae cardiau’n ailadrodd</div>
+                <p>
+                  Defnyddiwch y toglo ar y cerdyn. Mae <b>Ar hap</b> yn cymysgu’r dec; mae <b>Clyfar</b> yn defnyddio ailadrodd
+                  bylchog, gan ddod â chamgymeriadau’n ôl yn gynt a gadael cardiau a feistrolwyd i ymsuddo.
+                </p>
+              </div>
+              <div>
+                <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">3. Atebwch + dysgwch yn gyflym</div>
+                <p>
+                  Teipiwch y treiglad cywir, yna <b>Gwirio</b>. Defnyddiwch <b>Awgrym</b> neu <b>Datgelu</b> pan fyddwch yn sownd,
+                  a <b>Hepgor</b> i symud ymlaen. Darllenwch yr esboniad <b>Pam</b>, yna <b>Nesaf</b>.
+                </p>
+              </div>
+              <div>
+                <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">4. Gwrandewch a thraciwch gynnydd</div>
+                <p>
+                  Tapiwch <b>Gwrando</b> i glywed, a defnyddiwch <b>Mwy o ystadegau</b> ar gyfer cywirdeb, cyfresi, meistrolaeth
+                  yn ôl canlyniad/categori, a chynnydd y dec.
+                </p>
+              </div>
+            </div>
           </div>
 
           <div class="mt-3 flex gap-2">


### PR DESCRIPTION
### Motivation
- The onboarding panel was generic and no longer reflected the app’s current UI and features, so it needed clearer, task-focused guidance.
- The panel must remain bilingual and compatible with the existing language toggle behavior provided by the navbar code.
- The content should be more scannable and practically helpful so users can start practicing quickly.

### Description
- Rewrote the onboarding content in `index.html` for both English and Welsh, replacing the long numbered list with four scannable, task-oriented sections (focus selection, review modes, answering workflow, and listening/stats).
- Added small section headings and concise instructions that reference existing UI controls like `Start here` (Quick packs), `Core filters`, the card mode toggle (`Random` / `Smart`), `Check` / `Hint` / `Reveal` / `Skip`, `Hear`, and `More stats` to make the panel genuinely actionable.
- Kept the existing dismiss button (`#onboardDismiss`) and language-data attributes intact so language toggling and JS dismiss behavior remain unchanged.

### Testing
- Served the site locally with `python -m http.server 8000` and successfully rendered the page in a headless browser via a Playwright script that produced a screenshot at `artifacts/onboarding.png`.
- The change is content-only (HTML text/layout) and no runtime JS logic or unit tests were modified or required; the visual render check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697138f8a0cc8324b72da18f956d0e53)