### PR TITLE
Introduce contained practice card surface with footer and report action

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -465,8 +465,55 @@ body{
 
 /* ---------- Practice: core layout ---------- */
 #practiceCard > div{
-  max-width: 46rem;
+  max-width: 42.5rem;
   margin-inline: auto;
+}
+
+.practice-card-surface{
+  max-width: 42.5rem;
+  margin: 0 auto;
+  padding: 2.1rem 2.35rem;
+  border-radius: 1.75rem;
+  background: rgba(255,255,255,0.86);
+  border: 1px solid rgba(15,23,42,0.08);
+  box-shadow: 0 18px 36px rgba(15,23,42,0.08);
+}
+
+.practice-card-footer{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(15,23,42,0.08);
+  color: var(--muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.practice-card-meta{
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  font-size: 0.65rem;
+}
+
+.practice-report-btn{
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.6rem;
+  padding: 0.2rem 0.5rem;
+}
+
+@media (max-width: 640px){
+  .practice-card-surface{
+    padding: 1.6rem 1.4rem;
+  }
+  .practice-card-footer{
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .deck-progress{

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -342,6 +342,7 @@ const LABEL = {
       deckProgressLabel: "Deck progress",
       cardsRemainingLabel: "Remaining",
       cardIdLabel: "Card ID",
+      reportIssue: "Report issue",
     },
   },
   cy: {
@@ -422,6 +423,7 @@ const LABEL = {
       deckProgressLabel: "Cynnydd y dec",
       cardsRemainingLabel: "Ar ôl",
       cardIdLabel: "ID Cerdyn",
+      reportIssue: "Adrodd problem",
     },
   }
 };
@@ -1511,12 +1513,6 @@ function renderPractice() {
   headerLeft.appendChild(posSpan);
 
   const cardId = getCardId(card, idxShown);
-  if (cardId) {
-    const cardIdLine = document.createElement("span");
-    cardIdLine.className = "text-[10px] uppercase tracking-wide text-slate-400";
-    cardIdLine.textContent = `${LABEL[lang].ui.cardIdLabel}: ${cardId}`;
-    headerLeft.appendChild(cardIdLine);
-  }
 
   const deckTotal = state.practiceMode === "smart" ? n : state.deck.length;
   const deckReviewed = state.practiceMode === "smart"
@@ -1864,7 +1860,37 @@ function renderPractice() {
   answerBlock.className = "practice-answerBlock";
   answerBlock.append(row, actions, hint, feedback);
 
-  wrap.append(header, summary, instruction, chips, answerBlock);
+  const cardSurface = document.createElement("div");
+  cardSurface.className = "practice-card-surface";
+
+  const cardFooter = document.createElement("div");
+  cardFooter.className = "practice-card-footer";
+
+  const cardMeta = document.createElement("div");
+  cardMeta.className = "practice-card-meta";
+  cardMeta.textContent = `${LABEL[lang].ui.cardIdLabel}: ${cardId || "—"}`;
+
+  const reportLabel = LABEL[lang]?.ui?.reportIssue || (lang === "cy" ? "Adrodd problem" : "Report issue");
+  const reportBtn = document.createElement("button");
+  reportBtn.type = "button";
+  reportBtn.className = "btn btn-ghost practice-report-btn";
+  reportBtn.textContent = reportLabel;
+  reportBtn.title = reportLabel;
+  reportBtn.addEventListener("click", () => {
+    const subject = encodeURIComponent(`${LABEL[lang].ui.cardIdLabel}: ${cardId || "—"}`);
+    const sentence = buildCompleteSentence({ Before: card.Before, Answer: card.Answer, After: card.After });
+    const body = encodeURIComponent([
+      `${LABEL[lang].ui.cardIdLabel}: ${cardId || "—"}`,
+      `Base: ${card.Base || ""}`,
+      `Sentence: ${sentence}`
+    ].join("\n"));
+    window.location.href = `mailto:?subject=${subject}&body=${body}`;
+  });
+
+  cardFooter.append(cardMeta, reportBtn);
+  cardSurface.append(instruction, chips, answerBlock, cardFooter);
+
+  wrap.append(header, summary, cardSurface);
   host.appendChild(wrap);
 
   const ab = $("#answerBox");


### PR DESCRIPTION
### Motivation
- Make the practice card read as a single contained object with a fixed max width, padding, rounded corners and subtle surface contrast.  
- Surface the current card metadata and provide a simple way for users to report issues with a card.  
- Keep copy localized for English and Welsh UIs.

### Description
- Wrap the practice content in a new DOM wrapper `practice-card-surface` and move the instruction, base, input, actions and feedback inside it in `renderPractice()` in `js/mutation-trainer.js`.  
- Add a footer `practice-card-footer` that shows the `cardId` and a `Report issue` action which opens a prefilled `mailto:` with the card details.  
- Add localized label entries `reportIssue` for both English and Welsh in `LABEL`.  
- Add CSS rules in `css/styles.css` to constrain the card width (`max-width: 42.5rem`), provide generous padding, rounded corners, subtle background and shadow for `.practice-card-surface`, and layout/typography for `.practice-card-footer`, `.practice-card-meta` and `.practice-report-btn` with a small responsive tweak for narrow screens.

### Testing
- Launched a local dev server with `python -m http.server 8000` and verified the app loads successfully.  
- Used a Playwright script to load `http://127.0.0.1:8000/` at desktop viewport and capture a screenshot to validate the new contained card layout, which completed successfully.  
- No automated unit tests were run against the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697141780e4c832488f13079e65569ab)