### PR TITLE
Replace wide stats cards with a slim meta bar and move session controls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -469,6 +469,83 @@ body{
   margin-inline: auto;
 }
 
+.practice-meta-bar{
+  display:flex;
+  align-items:center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  margin-bottom: 1rem;
+  flex-wrap: nowrap;
+}
+
+.practice-meta-left{
+  display:flex;
+  align-items:center;
+  gap: 0.45rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.practice-meta-left .meta-item{
+  display:inline-flex;
+  align-items:baseline;
+  gap: 0.3rem;
+}
+
+.practice-meta-left .meta-label{
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.6rem;
+  color: rgba(100,116,139,0.85);
+}
+
+.practice-meta-left .meta-value{
+  font-weight: 600;
+  color: rgba(30,41,59,0.82);
+}
+
+.practice-meta-left .meta-sep{
+  color: rgba(100,116,139,0.65);
+}
+
+.practice-meta-left .meta-reset{
+  padding: 0.1rem 0.35rem;
+  font-size: 0.7rem;
+  color: rgba(100,116,139,0.7);
+}
+
+.practice-meta-right{
+  display:flex;
+  align-items:center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.practice-meta-bar .seg{
+  box-shadow: none;
+  background: rgba(255,255,255,0.65);
+  border-color: rgba(15,23,42,0.10);
+}
+
+.practice-meta-bar .seg-btn{
+  height: 1.7rem;
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+}
+
+.practice-meta-bar .btn-shuffle{
+  background: rgba(15,23,42,0.04);
+  border-color: rgba(15,23,42,0.12);
+  color: rgba(51,65,85,0.75);
+  box-shadow: none;
+}
+
+.practice-meta-bar .btn-shuffle:hover{
+  background: rgba(15,23,42,0.07);
+  border-color: rgba(15,23,42,0.18);
+  transform: translateY(-1px);
+}
+
 .practice-card-surface{
   max-width: 42.5rem;
   margin: 0 auto;
@@ -507,6 +584,13 @@ body{
 }
 
 @media (max-width: 640px){
+  .practice-meta-bar{
+    flex-wrap: wrap;
+  }
+  .practice-meta-right{
+    width: 100%;
+    justify-content: flex-start;
+  }
   .practice-card-surface{
     padding: 1.6rem 1.4rem;
   }

--- a/index.html
+++ b/index.html
@@ -142,22 +142,22 @@
       <div id="practiceView" class="grid md:grid-cols-3 gap-4 items-start">
         <!-- Left: practice card -->
         <div class="md:col-span-2 panel rounded-2xl p-6 md:p-7">
-          <!-- Compact stats strip (Ticket 5) -->
-          <div id="practiceStats" class="grid grid-cols-2 gap-2 mb-4">
-            <div class="rounded-xl border border-slate-200 bg-white p-2">
-              <div class="flex items-center justify-between mb-0.5">
-                <div id="practiceAccTitle" class="text-[10px] uppercase tracking-wide text-slate-500">Accuracy</div>
-                <button id="btnResetStatsTop" class="btn btn-ghost px-2 py-1 text-xs" title="Reset stats" type="button">↺</button>
-              </div>
-              <div id="practiceAcc" class="text-xl font-semibold">0%</div>
+          <!-- Slim meta bar (Ticket 2.1) -->
+          <div id="practiceMetaBar" class="practice-meta-bar">
+            <div class="practice-meta-left">
+              <span class="meta-item">
+                <span id="practiceAccTitle" class="meta-label">Accuracy</span>
+                <span id="practiceAcc" class="meta-value">0%</span>
+              </span>
+              <button id="btnResetStatsTop" class="btn btn-ghost meta-reset" title="Reset stats" type="button">↺</button>
+              <span class="meta-sep" aria-hidden="true">·</span>
+              <span class="meta-item">
+                <span id="practiceStreakTitle" class="meta-label">Streak</span>
+                <span class="meta-value"><span id="practiceStreak">0</span> <span aria-hidden="true">🔥</span></span>
+              </span>
+              <button id="btnResetStreakTop" class="btn btn-ghost meta-reset" title="Reset streak" type="button">↺</button>
             </div>
-            <div class="rounded-xl border border-slate-200 bg-white p-2">
-              <div class="flex items-center justify-between mb-0.5">
-                <div id="practiceStreakTitle" class="text-[10px] uppercase tracking-wide text-slate-500">Streak</div>
-                <button id="btnResetStreakTop" class="btn btn-ghost px-2 py-1 text-xs" title="Reset streak" type="button">↺</button>
-              </div>
-              <div class="text-xl font-semibold"><span id="practiceStreak">0</span> <span aria-hidden="true">🔥</span></div>
-            </div>
+            <div id="practiceMetaControls" class="practice-meta-right"></div>
           </div>
           <div id="practiceCard"></div>
         </div>

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1550,6 +1550,8 @@ function renderPractice() {
 
   const headerRight = document.createElement("div");
   headerRight.className = "flex items-center gap-2";
+  const metaControls = $("#practiceMetaControls");
+  if (metaControls) metaControls.innerHTML = "";
 
   const seg = document.createElement("div");
   seg.className = "seg";
@@ -1577,7 +1579,8 @@ function renderPractice() {
     mkSegBtn(t.smartModeShort, "smart")
   );
 
-  headerRight.appendChild(seg);
+  const controlsMount = metaControls || headerRight;
+  controlsMount.appendChild(seg);
   header.append(headerLeft, headerRight);
 
   const summary = document.createElement("div");
@@ -1787,7 +1790,11 @@ function renderPractice() {
   btnShuffle.onclick = () => { rebuildDeck(); render(); };
 
   main.append(btnCheck, btnHint, btnReveal, btnSkip);
-  aux.append(btnShuffle);
+  if (metaControls) {
+    metaControls.appendChild(btnShuffle);
+  } else {
+    aux.append(btnShuffle);
+  }
   actions.append(main, aux);
 
   const feedback = document.createElement("div");


### PR DESCRIPTION
### Motivation
- Replace the two large Accuracy/Streak stat cards above the practice card with a single slim, low-contrast meta bar so stats are glanceable and do not compete visually with the card. 
- Surface `Random/Smart` and `Shuffle` controls in the same row as the stats and give them visually secondary styling. 
- Preserve existing functionality and ensure the bar stays on one row on desktop and may wrap to two rows on small screens.

### Description
- Replaced the two-card stats markup with a compact meta bar in `index.html` using `#practiceMetaBar`, `#practiceMetaControls`, and preserved existing IDs `#practiceAcc`, `#practiceStreak`, `#btnResetStatsTop`, and `#btnResetStreakTop` for compatibility. 
- Added styles in `css/styles.css` (`.practice-meta-bar`, `.practice-meta-left`, `.practice-meta-right`, and small responsive rules) to make the bar calm, muted, and responsive (no awkward wrapping on desktop). 
- Updated `js/mutation-trainer.js` to mount the segmented `Random/Smart` control and `Shuffle` button into the meta bar when present, while falling back to the previous placement if the mount is absent, keeping all behavior unchanged. 
- Files changed: `index.html`, `css/styles.css`, `js/mutation-trainer.js`.

### Testing
- Render verification: started a local HTTP server and captured a headless browser screenshot of `index.html` at `1280x720` using Playwright to validate layout; the screenshot run completed successfully and produced an artifact. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697144e853bc832494cc8dd6f2de65d8)