### PR TITLE
Add single-line practice progress indicator under meta bar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -474,7 +474,7 @@ body{
   align-items:center;
   justify-content: space-between;
   gap: 0.85rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.4rem;
   flex-wrap: nowrap;
 }
 
@@ -546,6 +546,34 @@ body{
   transform: translateY(-1px);
 }
 
+.practice-progress{
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1.1rem;
+}
+
+.practice-progress-line{
+  font-size: 0.78rem;
+  color: rgba(71,85,105,0.85);
+  letter-spacing: 0.02em;
+}
+
+.practice-progress-bar{
+  height: 0.28rem;
+  border-radius: 999px;
+  background: rgba(15,23,42,0.08);
+  overflow: hidden;
+}
+
+.practice-progress-bar-fill{
+  height: 100%;
+  width: 0%;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(148,163,184,0.55) 0%, rgba(148,163,184,0.35) 100%);
+  transition: width .28s ease;
+}
+
 .practice-card-surface{
   max-width: 42.5rem;
   margin: 0 auto;
@@ -591,6 +619,9 @@ body{
     width: 100%;
     justify-content: flex-start;
   }
+  .practice-progress{
+    margin-bottom: 0.9rem;
+  }
   .practice-card-surface{
     padding: 1.6rem 1.4rem;
   }
@@ -598,36 +629,6 @@ body{
     flex-direction: column;
     align-items: flex-start;
   }
-}
-
-.deck-progress{
-  display: grid;
-  gap: 0.35rem;
-}
-
-.deck-progress-top{
-  display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
-  font-size: 0.7rem;
-  color: rgba(71,85,105,0.9);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.deck-progress-track{
-  height: 0.4rem;
-  border-radius: 999px;
-  background: rgba(15,23,42,0.12);
-  overflow: hidden;
-}
-
-.deck-progress-fill{
-  height: 100%;
-  width: 0%;
-  border-radius: 999px;
-  background: linear-gradient(135deg, var(--primary-from) 0%, var(--primary-mid) 45%, var(--primary-to) 100%);
-  transition: width .28s ease;
 }
 
 /* Instruction spacing */

--- a/index.html
+++ b/index.html
@@ -159,6 +159,12 @@
             </div>
             <div id="practiceMetaControls" class="practice-meta-right"></div>
           </div>
+          <div id="practiceProgress" class="practice-progress" aria-live="polite">
+            <div id="practiceProgressLine" class="practice-progress-line"></div>
+            <div id="practiceProgressBar" class="practice-progress-bar" aria-hidden="true">
+              <div id="practiceProgressBarFill" class="practice-progress-bar-fill"></div>
+            </div>
+          </div>
           <div id="practiceCard"></div>
         </div>
 


### PR DESCRIPTION
### Motivation
- Provide a small, calm signal of current focus and position so users can see “where I am” and “how big this set is” without opening More stats.
- Ensure the progress updates reliably when the deck, preset, filters, or shuffle mode change.

### Description
- Add a new progress region under the meta bar in `index.html` with `#practiceProgress`, `#practiceProgressLine`, and an optional thin bar (`#practiceProgressBarFill`).
- Add muted styling for the line and bar in `css/styles.css`, adjust spacing around the meta bar, and remove the older deck-progress layout to avoid noisy blocks.
- Add localization keys `progressAllCards` and `progressCustomFilters` to `LABEL` and implement `hasCustomFilters()`, `getProgressFocusLabel()` and `updateProgressLine()` in `js/mutation-trainer.js` to compute the focus label and update counts and bar width.
- Wire updates into `renderPractice()` so the progress line is updated when the filtered set is empty, when using `smart` mode, on normal deck position changes, and when filters/presets change; replace previous `deck-progress` DOM output with the new compact line.

### Testing
- Launched a simple HTTP server with `python -m http.server` and ran a headless Playwright script to open `index.html` and capture a screenshot of the progress area, which completed and produced `artifacts/progress-line.png` (smoke test succeeded).
- All modified files were staged and committed locally via `git commit` (commit successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971466f0534832490a6490581737738)