### PR TITLE
Emphasize 'Check' as primary action; add action hierarchy and responsive layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -374,6 +374,20 @@ body{
   box-shadow: 0 10px 22px rgba(2,6,23,0.08);
 }
 
+.btn-muted{
+  background: rgba(148,163,184,0.10);
+  border-color: rgba(148,163,184,0.35);
+  color: var(--muted);
+  box-shadow: none;
+}
+.btn-muted:hover{
+  background: rgba(148,163,184,0.16);
+  border-color: rgba(148,163,184,0.45);
+  color: #334155;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(2,6,23,0.08);
+}
+
 /* ---------- Language toggle (fix pill-in-pill) ---------- */
 .btn-lang{
   display:inline-flex;
@@ -707,6 +721,21 @@ body{
   align-items:center;
   gap: 0.65rem;
 }
+#practiceCard .practice-actions-primary{
+  display:flex;
+  align-items:center;
+}
+#practiceCard .practice-actions-secondary{
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap: 0.65rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+#practiceCard .practice-actions-secondary .btn-skip{
+  margin-left:auto;
+}
 #practiceCard .practice-actions-aux{
   display:flex;
   align-items:center;
@@ -717,6 +746,36 @@ body{
 #practiceCard .practice-actions .btn-shuffle,
 #practiceCard .practice-actions .btn-shuffleNow{
   margin-left:auto;
+}
+
+@media (max-width: 640px){
+  #practiceCard .practice-actions{
+    flex-direction: column;
+    align-items: stretch;
+  }
+  #practiceCard .practice-actions-main{
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+  #practiceCard .practice-actions-primary{
+    width: 100%;
+  }
+  #practiceCard .practice-actions-primary .btn-check{
+    width: 100%;
+    justify-content: center;
+  }
+  #practiceCard .practice-actions-secondary{
+    width: 100%;
+    justify-content: flex-start;
+  }
+  #practiceCard .practice-actions-secondary .btn{
+    padding: .45rem .75rem;
+    font-size: 0.9rem;
+  }
+  #practiceCard .practice-actions-secondary .btn-skip{
+    margin-left: auto;
+  }
 }
 
 /*fix button alignment*/

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1693,6 +1693,12 @@ function renderPractice() {
   const main = document.createElement("div");
   main.className = "practice-actions-main";
 
+  const primary = document.createElement("div");
+  primary.className = "practice-actions-primary";
+
+  const secondary = document.createElement("div");
+  secondary.className = "practice-actions-secondary";
+
   const aux = document.createElement("div");
   aux.className = "practice-actions-aux";
 
@@ -1733,7 +1739,7 @@ function renderPractice() {
     setTimeout(() => $("#inlineNext")?.focus({ preventScroll: true }), 0);
   };
 
-  const btnCheck = btn(t.check, "btn-primary shadow", onCheck);
+  const btnCheck = btn(t.check, "btn-primary btn-check shadow", onCheck);
   btnCheck.id = "btnCheck";
   btnCheck.title = `${t.check} (Enter)`;
 
@@ -1753,7 +1759,7 @@ function renderPractice() {
     render();
   });
 
-  const btnSkip = btn(t.skip, "btn-ghost", () => {
+  const btnSkip = btn(t.skip, "btn-ghost btn-muted btn-skip", () => {
     state.guess = "";
     state.revealed = true;
     state.lastResult = "skipped";
@@ -1797,7 +1803,9 @@ function renderPractice() {
   btnShuffle.innerHTML = `<span aria-hidden="true">🔀</span><span>${esc(t.shuffleNow)}</span>`;
   btnShuffle.onclick = () => { rebuildDeck(); render(); };
 
-  main.append(btnCheck, btnHint, btnReveal, btnSkip);
+  primary.append(btnCheck);
+  secondary.append(btnHint, btnReveal, btnSkip);
+  main.append(primary, secondary);
   if (metaControls) {
     metaControls.appendChild(btnShuffle);
   } else {


### PR DESCRIPTION
### Motivation
- Make `Check` visually dominant as the single primary action while demoting other actions to secondary roles for clearer affordance.
- Ensure `Hint` and `Reveal` act as secondary (outline/ghost) actions and `Skip` is muted and positioned to the right to avoid equal weighting.
- On mobile, make `Check` full-width and place other actions in a compact row beneath to preserve a clear primary action on small screens.

### Description
- Added a muted secondary button style `.btn-muted` to `css/styles.css` and hover state to support a subdued `Skip` control.
- Introduced structural classes `.practice-actions-primary` and `.practice-actions-secondary` and responsive layout rules in `css/styles.css` to separate primary vs secondary actions and to implement mobile stacking behavior.
- Updated `renderPractice()` in `js/mutation-trainer.js` to create `primary` and `secondary` containers, append `btnCheck` into `.practice-actions-primary`, and append `btnHint`, `btnReveal`, and `btnSkip` (now `btn-muted btn-skip`) into `.practice-actions-secondary`.
- Added `btn-check` and `btn-skip` classes to the respective buttons to wire up the new CSS rules and alignment.

### Testing
- Launched a local HTTP server and exercised the UI with a Playwright script that captured desktop and mobile screenshots (`artifacts/action-hierarchy-desktop.png` and `artifacts/action-hierarchy-mobile.png`), which completed successfully.
- No unit tests were added or modified for these static UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697148c3f6408324985f6b5569c9463a)