### PR TITLE
Anchor base-word capsule and adjust help icon positioning

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -659,7 +659,7 @@ body{
   justify-content:center;
   margin: .8rem 0 2rem;
 }
-#practiceCard .practice-base .bg-indigo-100.ring-1.ring-indigo-300.rounded-2xl{
+#practiceCard .practice-base .base-word-capsule{
   position: relative; /* anchor the “?” */
   display:inline-flex !important;
   align-items:center !important;
@@ -907,8 +907,19 @@ body{
 
 .base-info-btn{
   position:absolute;
-  top:-0.30rem;
-  right:-0.50rem;
+  top:50%;
+  right:-0.65rem;
+  transform: translate(50%, -50%);
+}
+
+@media (max-width: 480px){
+  #practiceCard .practice-base{
+    padding-inline: 0.6rem;
+  }
+  .base-info-btn{
+    right:-0.3rem;
+    transform: translate(50%, -50%);
+  }
 }
 
 .base-info-popover{

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1663,7 +1663,7 @@ function renderPractice() {
   chips.className = "practice-base text-2xl md:text-3xl font-medium";
 
   const capsule = document.createElement("div");
-  capsule.className = "inline-flex items-baseline bg-indigo-100 ring-1 ring-indigo-300 rounded-2xl px-5 py-2.5 shadow-sm";
+  capsule.className = "base-word-capsule inline-flex items-center bg-indigo-100 ring-1 ring-indigo-300 rounded-2xl px-5 py-2.5 shadow-sm";
   capsule.style.position = "relative";
 
   const baseSpan = document.createElement("span");


### PR DESCRIPTION
### Motivation
- Ensure the base word block is the clear visual anchor while keeping the help (❓) and hear (🔊) affordances adjacent and usable. 
- Prevent icons from overlapping the base word on narrow viewports so the card reads as centred and intentional.

### Description
- Added a dedicated `base-word-capsule` class and moved the base capsule styling to `#practiceCard .practice-base .base-word-capsule` in `css/styles.css` to centralise layout rules. 
- Replaced the inline capsule class in `js/mutation-trainer.js` so the capsule is created with `className = "base-word-capsule inline-flex items-center ..."`. 
- Repositioned the base help button (`.base-info-btn`) to vertically centre at the capsule’s right edge and added an `@media (max-width: 480px)` rule to reduce padding and nudge the icon inward to avoid overlap. 

### Testing
- Served the app with `python -m http.server 8000` and opened `index.html` via a Playwright script which loaded the page at `http://127.0.0.1:8000/index.html` and produced a screenshot `artifacts/base-word-anchor.png`, confirming visual placement; the script completed successfully. 
- Changes were staged and committed locally with a descriptive commit message; no automated test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697149ee0c388324be5a7ac0b10a6319)