### PR TITLE
Stabilize feedback panel layout and add collapsible “Why”

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -802,13 +802,68 @@ body{
   box-shadow: 0 10px 18px rgba(2,6,23,0.10);
 }
 
-/* Feedback box */
+/* Feedback panel */
+#practiceCard .practice-feedback{
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: max-height 0.35s ease, opacity 0.25s ease, transform 0.25s ease;
+}
+
+#practiceCard .practice-feedback.is-visible{
+  max-height: 1200px;
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .feedback-box{
   background: rgba(4,120,87,0.05);
   border: 1px solid rgba(4,120,87,0.20);
   border-radius: 0.75rem;
   padding: 1rem;
   margin-top: 1.5rem;
+}
+
+.feedback-why{
+  margin-top: 1rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(148,163,184,0.12);
+  border-radius: 0.65rem;
+}
+
+.feedback-why summary{
+  cursor: pointer;
+  font-weight: 600;
+  color: rgba(30,41,59,0.9);
+  list-style: none;
+}
+
+.feedback-why summary::-webkit-details-marker{
+  display: none;
+}
+
+.feedback-why summary::after{
+  content: "▾";
+  display: inline-block;
+  margin-left: 0.45rem;
+  font-size: 0.85rem;
+  transition: transform 0.2s ease;
+}
+
+.feedback-why[open] summary::after{
+  transform: rotate(180deg);
+}
+
+.feedback-why-body{
+  margin-top: 0.55rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 640px){
+  .feedback-why{
+    padding: 0.55rem 0.65rem;
+  }
 }
 
 /* ---------- HEAR button (tight, lighter weight, better icon) ---------- */

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -385,6 +385,7 @@ const LABEL = {
       cardsRemainingLabel: "Remaining",
       cardIdLabel: "Card ID",
       reportIssue: "Report issue",
+      whyLabel: "Why",
     },
   },
   cy: {
@@ -468,6 +469,7 @@ const LABEL = {
       cardsRemainingLabel: "Ar ôl",
       cardIdLabel: "ID Cerdyn",
       reportIssue: "Adrodd problem",
+      whyLabel: "Pam",
     },
   }
 };
@@ -1818,12 +1820,24 @@ function renderPractice() {
   feedback.setAttribute("aria-live", "polite");
 
   if (state.revealed) {
+    feedback.classList.add("is-visible");
     const ok = state.lastResult === "correct";
     const skipped = state.lastResult === "skipped";
 
     const statusIcon = skipped ? "⏭️" : (ok ? "✅" : "❌");
     const statusColor = skipped ? "text-slate-800" : (ok ? "text-indigo-900" : "text-rose-900");
     const statusText = skipped ? t.statuses.skipped : (ok ? t.statuses.correct : t.statuses.wrong);
+    const whyText = (state.lang === "cy" ? (card.WhyCym || card.Why) : card.Why) || "";
+    const whyLabel = LABEL?.[lang]?.ui?.whyLabel || (lang === "cy" ? "Pam" : "Why");
+    const isMobile = window.matchMedia("(max-width: 640px)").matches;
+    const whyMarkup = whyText
+      ? `
+        <details class="feedback-why" ${isMobile ? "" : "open"}>
+          <summary>${esc(whyLabel)}</summary>
+          <div class="feedback-why-body text-slate-700">${esc(whyText)}</div>
+        </details>
+      `
+      : "";
 
     feedback.innerHTML = `
       <div class="feedback-box">
@@ -1847,10 +1861,7 @@ function renderPractice() {
           </button>
         </div>
 
-        ${(() => {
-          const whyText = (state.lang === "cy" ? (card.WhyCym || card.Why) : card.Why) || "";
-          return whyText ? `<div class="mt-4 text-slate-700">${esc(whyText)}</div>` : "";
-        })()}
+        ${whyMarkup}
 
         <div class="mt-4 flex justify-end">
           <button id="inlineNext"
@@ -1877,6 +1888,8 @@ function renderPractice() {
       }
       $("#inlineNext")?.addEventListener("click", () => nextCard(1));
     }, 0);
+  } else {
+    feedback.classList.add("is-hidden");
   }
 
   const answerBlock = document.createElement("div");


### PR DESCRIPTION
### Motivation
- Keep the feedback UI visually part of the card and avoid jarring layout jumps when the answer is revealed by reserving/animating space inside the card.
- Ensure the feedback’s `Hear` button remains inside the feedback area and aligned consistently.
- Make the explanatory `Why` text readable on small screens by making it collapsible by default on mobile.

### Description
- Animate the feedback container by adding CSS rules for `#practiceCard .practice-feedback` with a hidden default and an `.is-visible` state that transitions `max-height`, `opacity`, and `transform` to prevent layout jumps.
- Render feedback visibility by adding/removing the `is-visible` (and `is-hidden`) classes in `renderPractice()` when `state.revealed` is true/false.
- Replace inline `Why` rendering with a `<details class="feedback-why">` block that is `open` on desktop but collapses by default on mobile via `window.matchMedia`, and add corresponding styles for `summary` and `.feedback-why-body`.
- Add `whyLabel` translation keys for both English and Welsh and use the label for the `details` summary so the collapse control is localizable.

### Testing
- Started a local static server with `python -m http.server 8000` successfully to serve the app for a smoke test.
- Attempted an automated Playwright smoke test to fill `#answerBox`, click `#btnCheck` and capture a screenshot, but the Playwright run timed out / the headless browser crashed in this environment and the UI screenshot step failed.
- No other automated tests (unit/lint) were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714b293298832492fad0f6062a9c9c)