### PR TITLE
Unify categories filter with progressive disclosure

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -199,6 +199,24 @@ body{
   transition: transform .08s ease, box-shadow .12s ease, background .12s ease, border-color .12s ease;
 }
 
+.pill-core{
+  border-color: rgba(148,163,184,.5);
+  background: rgba(255,255,255,.95);
+}
+
+.pill-extra{
+  font-weight: 600;
+  color: #64748b;
+  background: rgba(248,250,252,.9);
+}
+
+.pill-more{
+  font-weight: 700;
+  border-style: dashed;
+  background: rgba(241,245,249,.95);
+  color: #0f172a;
+}
+
 /* ----- Phase 1: Preset cards ----- */
 .preset-card{
   background: var(--surface);

--- a/index.html
+++ b/index.html
@@ -195,8 +195,18 @@
                     <div id="familyBtns" class="flex flex-wrap gap-1"></div>
                   </div>
                   <div class="col-span-1">
-                    <div id="basicCategoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Common categories</div>
-                    <div id="basicCatBtns" class="flex flex-wrap gap-1"></div>
+                    <div id="categoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Categories</div>
+                    <div id="categoryChips" class="flex flex-wrap gap-1"></div>
+                    <div id="categoryExtras" class="mt-2 hidden">
+                      <div class="mt-2">
+                        <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
+                        <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
+                      </div>
+                      <label class="inline-flex items-center gap-2 text-sm mt-1">
+                        <input id="nilOnly" type="checkbox" />
+                        <span id="nilOnlyText">Nil-cases only (no mutation expected)</span>
+                      </label>
+                    </div>
                   </div>
                 </div>
                 <!-- Clear filters button (core) -->
@@ -205,26 +215,6 @@
                 </div>
               </div>
             </div>
-
-            <!-- Advanced filters collapsed by default -->
-            <details id="advFilters" class="mt-3">
-              <summary id="advToggle" class="cursor-pointer text-sm font-medium select-none">More filters</summary>
-              <div class="mt-2">
-                <!-- Advanced categories (non-duplicated) -->
-                <div id="advCategoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">All categories</div>
-                <div id="advCategoriesHelper" class="text-xs text-slate-500 mb-2"></div>
-                <div id="catBtns" class="flex flex-wrap gap-1"></div>
-                <div class="mt-2">
-                  <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
-                  <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
-                </div>
-                <label class="inline-flex items-center gap-2 text-sm mt-1">
-                  <input id="nilOnly" type="checkbox" />
-                  <span id="nilOnlyText">Nil-cases only (no mutation expected)</span>
-                </label>
-
-              </div>
-            </details>
           </div>
 
             <!-- Session stats hidden under details -->


### PR DESCRIPTION
### Motivation
- Remove duplicated "Common categories" / "All categories" UI and provide a single, clearer `Categories` control with progressive disclosure to reduce user confusion.
- Surface core category chips by default, with an inline expansion for secondary categories, trigger search, and nil-cases to keep the primary view compact.

### Description
- Replace the split category panels in `index.html` with a single `#categoryChips` area and an expandable `#categoryExtras` block that contains the trigger input and `nilOnly` checkbox.
- Introduce `CORE_CATEGORIES` and a `showMoreFilters` state flag (persisted via `wm_show_more_filters`) and compute `extraCats = allCats.filter(...)` in `js/mutation-trainer.js`.
- Render chips in the order `All` + core chips + a `More/Fewer` chip (`#moreFiltersChip`) and, when expanded, append the remaining category chips and reveal the trigger input and nil-cases control; ensure chips are multi-select and not duplicated by filtering out `All` and core set from extras.
- Update localization entries for the `More/Fewer` chip and trigger placeholder and wire those into `applyLanguage`; remove the old advanced details panel and related labels.
- Add CSS classes `.pill-core`, `.pill-extra`, and `.pill-more` in `css/styles.css` to make core chips visually stronger, expanded-only chips softer, and the toggle distinct.

### Testing
- Ran a visual smoke test by serving the app with `python -m http.server` and capturing a screenshot via a Playwright script, which executed successfully and produced `artifacts/categories-filters.png`.
- No automated unit tests were present or executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69715caa00448324a2ce2f8ff8af5968)