### PR TITLE
Refactor filter pills: inline More/Less toggle, Clear button, remove nil-only filter

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -285,6 +285,10 @@ body{
   transition: transform .08s ease, box-shadow .12s ease, background .12s ease, border-color .12s ease;
 }
 
+.pill-group{
+  display: contents;
+}
+
 .pill-core{
   border-color: rgba(148,163,184,.5);
   background: rgba(255,255,255,.95);
@@ -433,13 +437,14 @@ body{
 .pill:active{ transform: translateY(0px); box-shadow: 0 6px 12px rgba(2,6,23,0.05); }
 
 .pill-on{
-  background:rgba(4,120,87,.12);
-  border-color:rgba(4,120,87,.26);
-  box-shadow:none;
+  background: rgba(16,185,129,.28);
+  border-color: rgba(5,150,105,.7);
+  color: #065f46;
+  box-shadow: inset 0 0 0 1px rgba(5,150,105,.35);
 }
 .pill-on:hover{
-  background: rgba(4,120,87,0.15);
-  border-color: rgba(4,120,87,0.34);
+  background: rgba(16,185,129,0.34);
+  border-color: rgba(5,150,105,0.8);
 }
 
 /* ---------- Buttons (base) ---------- */

--- a/index.html
+++ b/index.html
@@ -205,35 +205,26 @@
                           </div>
                           <div class="col-span-1">
                             <div id="categoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Categories</div>
-                            <div id="coreCategoryChips" class="flex flex-wrap gap-1"></div>
-                            <div id="extraCategoryChips" class="flex flex-wrap gap-1 is-hidden"></div>
+                            <div id="categoryPills" class="flex flex-wrap gap-1 items-center">
+                              <div id="coreCategoryChips" class="pill-group"></div>
+                              <div id="extraCategoryChips" class="pill-group is-hidden"></div>
+                              <div id="allCategoryChips" class="pill-group is-hidden"></div>
+                              <button id="moreFiltersToggle" class="pill pill-more" type="button">More filters</button>
+                              <button id="btnFiltersClear" class="pill pill-clear" type="button">
+                                <span class="pill-label">Clear filters</span>
+                                <span class="pill-icon" aria-hidden="true">×</span>
+                              </button>
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
                     <div id="moreFiltersPanel" class="filters-extra is-hidden">
-                      <div class="col-span-1 mb-3">
-                        <div id="allCategoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">All categories</div>
-                        <div id="allCategoryChips" class="flex flex-wrap gap-1"></div>
-                      </div>
                       <div class="mt-2">
                         <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
                         <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
                       </div>
-                      <label class="inline-flex items-center gap-2 text-sm mt-2">
-                        <input id="nilOnly" type="checkbox" />
-                        <span id="nilOnlyText">Nil-cases only (no mutation expected)</span>
-                      </label>
-                      <div class="mt-3 flex flex-wrap gap-1">
-                        <button id="moreFiltersClose" class="pill pill-close" type="button">Close filters</button>
-                      </div>
-                    </div>
-                    <div class="mt-3 flex flex-wrap gap-1">
-                      <button id="moreFiltersToggle" class="pill pill-more" type="button">More filters</button>
-                    </div>
-                    <div class="mt-3 flex flex-wrap gap-1">
-                      <button id="btnFiltersClear" class="pill pill-clear" type="button">Clear filters</button>
-                      <button id="moreFiltersToggle" class="pill pill-more" type="button">More filters</button>
+                      <div class="mt-3 flex flex-wrap gap-1"></div>
                     </div>
                   </details>
                 </div>

--- a/js/card.js
+++ b/js/card.js
@@ -218,11 +218,9 @@ export function renderPractice() {
       state.families = ["Soft","Aspirate","Nasal","None"];
       state.categories = [];
       state.triggerQuery = "";
-      state.nilOnly = false;
       saveLS("wm_families", state.families);
       saveLS("wm_categories", state.categories);
       saveLS("wm_trig", state.triggerQuery);
-      saveLS("wm_nil", state.nilOnly);
       cardCallbacks.applyFilters?.();
       cardCallbacks.rebuildDeck?.();
       cardCallbacks.buildFilters?.();
@@ -408,19 +406,15 @@ export function renderPractice() {
       const trigLabel = (lang === "cy" ? "Sbardun" : "Trigger");
       summary.appendChild(addChip(`${trigLabel}: ${state.triggerQuery.trim()}`));
     }
-    if (state.nilOnly) summary.appendChild(addChip(label("headings", "nilOnly")));
-
     // Use translated "Clear" label for the final chip
     const clearLabel = LABEL[lang]?.ui?.clear || (lang === "cy" ? "Clirio" : "Clear");
     summary.appendChild(addChip(clearLabel, () => {
       state.families = ["Soft","Aspirate","Nasal","None"];
       state.categories = [];
       state.triggerQuery = "";
-      state.nilOnly = false;
       saveLS("wm_families", state.families);
       saveLS("wm_categories", state.categories);
       saveLS("wm_trig", state.triggerQuery);
-      saveLS("wm_nil", state.nilOnly);
       cardCallbacks.applyFilters?.();
       cardCallbacks.rebuildDeck?.();
       cardCallbacks.buildFilters?.();

--- a/js/state.js
+++ b/js/state.js
@@ -95,7 +95,6 @@ export const state = {
   presetLimitComplexity: loadLS("wm_preset_limit_complexity", false),
   presetCategory: loadLS("wm_preset_category", null),
   showMoreFilters: loadLS("wm_show_more_filters", false),
-  nilOnly: loadLS("wm_nil", false),
   mode: loadLS("wm_mode", "practice"),
   practiceMode: loadLS(PRACTICE_MODE_LS_KEY, "shuffle"),
   leitner: loadLS(LEITNER_LS_KEY, {}),
@@ -127,8 +126,7 @@ export function hasCustomFilters() {
   return (
     (state.families.length && state.families.length < 4) ||
     activeCategories.length ||
-    (state.triggerQuery && state.triggerQuery.trim()) ||
-    state.nilOnly
+    (state.triggerQuery && state.triggerQuery.trim())
   );
 }
 
@@ -141,12 +139,10 @@ export function resetFilters() {
   state.families = ["Soft","Aspirate","Nasal","None"];
   state.categories = [];
   state.triggerQuery = "";
-  state.nilOnly = false;
 
   saveLS("wm_families", state.families);
   saveLS("wm_categories", state.categories);
   saveLS("wm_trig", state.triggerQuery);
-  saveLS("wm_nil", state.nilOnly);
 }
 
 state.families = Array.isArray(state.families) && state.families.length
@@ -162,7 +158,7 @@ state.presetLimitComplexity = Boolean(state.presetLimitComplexity);
 /* ========= UI Translations ========= */
 export const LABEL = {
   en: {
-    headings: { focus:"Focus", rulefamily:"Mutation type", outcome:"Outcome", categories:"Categories", allCategories:"All categories", trigger:"Filter by Trigger", nilOnly:"Nil-cases only (no mutation expected)", presets:"Quick packs" },
+    headings: { focus:"Focus", rulefamily:"Mutation type", outcome:"Outcome", categories:"Categories", allCategories:"All categories", trigger:"Filter by Trigger", presets:"Quick packs" },
     presets: {
       starterPrepsTitle: "Starter prepositions",
       starterPrepsDesc: "Common contact-mutation prepositions",
@@ -271,7 +267,7 @@ export const LABEL = {
     },
   },
   cy: {
-    headings: { focus:"Ffocws", rulefamily:"Math treiglad", outcome:"Canlyniad", categories:"Categorïau", allCategories:"Pob categori", trigger:"Hidlo yn ôl y sbardun", nilOnly:"Achosion dim-treiglad yn unig (dim treiglad disgwyliedig)", presets:"Pecynnau cyflym" },
+    headings: { focus:"Ffocws", rulefamily:"Math treiglad", outcome:"Canlyniad", categories:"Categorïau", allCategories:"Pob categori", trigger:"Hidlo yn ôl y sbardun", presets:"Pecynnau cyflym" },
     presets: {
       starterPrepsTitle: "Arddodiaid dechreuol",
       starterPrepsDesc: "Arddodiaid treiglad-cyswllt cyffredin",


### PR DESCRIPTION
### Motivation
- Make the category filter pills behave as a single inline row with the "More/Less filters" toggle and the "Clear filters ×" control positioned at the end of the core category pills. 
- Remove the obsolete "nil-cases only" control and duplicate/extra buttons and labels so the filter UI is cleaner and clearer. 

### Description
- Reworked HTML structure so the core/extra/all category chips and controls are grouped inline in `index.html` under `#categoryPills`, moving `#moreFiltersToggle` and `#btnFiltersClear` to the end of the pill row. 
- Removed the `nilOnly` checkbox and related labels from the DOM and removed corresponding wiring and filtering logic across the codebase (`index.html`, `js/mutation-trainer.js`, `js/card.js`). 
- Updated state handling in `js/state.js` to drop `nilOnly` from the state, `resetFilters`, and `hasCustomFilters` logic, and removed `nilOnly` headings from `LABEL`. 
- Wired the inline `#moreFiltersToggle` so it toggles the expanded panel and the extra/all category chips (`#allCategoryChips`) and updates its translated label to show "More filters" / "Fewer filters" as appropriate; applied `applyPillState` to `#allCategoryChips` as well. 
- Adjusted the clear filters wiring to update the new inline `#btnFiltersClear` label and to call `clearFiltersAndRender()` where appropriate. 
- Improved active-state styling and added `.pill-group` helper in `css/styles.css` and strengthened `.pill-on` styles so active vs inactive pills are clearer. 

### Testing
- Launched a local static HTTP server and attempted an end-to-end browser interaction using Playwright to expand the filters and capture a screenshot, but the headless Chromium process crashed so the run failed and no screenshot was produced. 
- No unit tests or automated linters were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a8df9b748324b57eb81136901a2b)