### PR TITLE
Polish practice stats (accuracy & streak) UI with subtle animations

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -643,9 +643,61 @@ body{
 .practice-meta-left{
   display:flex;
   align-items:center;
-  gap: 0.45rem;
+  gap: 0.6rem;
   color: var(--muted);
   font-size: 0.75rem;
+}
+
+.statsRow{
+  display:flex;
+  gap: 10px;
+  align-items:center;
+}
+
+.statPill{
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.65);
+  border: 1px solid rgba(0,0,0,0.06);
+  box-shadow: 0 2px 10px rgba(0,0,0,0.04);
+  min-width: 92px;
+}
+
+.statValue{
+  display:flex;
+  align-items:baseline;
+  gap: 6px;
+  font-weight: 800;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+  color: inherit;
+  line-height: 1.05;
+}
+
+.statUnit{
+  font-size: 12px;
+  font-weight: 700;
+  opacity: 0.75;
+}
+
+.statLabel{
+  margin-top: 2px;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
+.statIcon{
+  transform: translateY(-1px);
+  opacity: 0.9;
+}
+
+.practice-meta-left .meta-reset{
+  align-self: center;
 }
 
 .practice-meta-left .meta-item{
@@ -688,6 +740,17 @@ body{
   padding: 0.15rem 0.45rem;
   font-size: 0.9rem;
   line-height: 1;
+}
+
+@media (hover:hover){
+  .statPill{
+    transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+  }
+  .statPill:hover{
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(0,0,0,0.08);
+    border-color: rgba(0,0,0,0.10);
+  }
 }
 
 .meta-more-wrap{
@@ -989,7 +1052,23 @@ body{
   }
 }
 
+@media (max-width: 768px){
+  .statPill{
+    padding: 8px 10px;
+    min-width: 78px;
+  }
+  .statValue{
+    font-size: 16px;
+  }
+  .statLabel{
+    font-size: 10px;
+  }
+}
+
 @media (prefers-reduced-motion: reduce){
+  .statPill{
+    transition: none !important;
+  }
   #practiceCard .practice-card-face{
     transition: none;
   }
@@ -998,6 +1077,18 @@ body{
   #practiceCard .practice-card-flip.is-front .practice-card-face.is-back,
   #practiceCard .practice-card-flip.is-back .practice-card-face.is-front{
     transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference){
+  .pulse{
+    animation: pulsePop 420ms ease-out;
+  }
+
+  @keyframes pulsePop{
+    0%{ transform: scale(1); }
+    40%{ transform: scale(1.06); }
+    100%{ transform: scale(1); }
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -144,15 +144,21 @@
           <div id="practiceHeader" class="practice-header">
             <div id="practiceMetaBar" class="practice-meta-bar">
               <div class="practice-meta-left">
-                <span class="meta-item meta-accuracy">
-                  <span id="practiceAccTitle" class="meta-label">Accuracy</span>
-                  <span id="practiceAcc" class="meta-value">0%</span>
-                </span>
-                <span class="meta-sep" aria-hidden="true">·</span>
-                <span class="meta-item meta-streak">
-                  <span id="practiceStreakTitle" class="meta-label">Streak</span>
-                  <span class="meta-value"><span aria-hidden="true">🔥</span><span id="practiceStreak">0</span></span>
-                </span>
+                <div class="statsRow" aria-label="Stats">
+                  <div class="statPill" id="statAccuracy" aria-label="Accuracy">
+                    <div class="statValue">
+                      <span id="practiceAcc">0</span><span class="statUnit">%</span>
+                    </div>
+                    <div id="practiceAccTitle" class="statLabel">Accuracy</div>
+                  </div>
+                  <div class="statPill" id="statStreak" aria-label="Streak">
+                    <div class="statValue">
+                      <span class="statIcon" aria-hidden="true">🔥</span>
+                      <span id="practiceStreak">0</span>
+                    </div>
+                    <div id="practiceStreakTitle" class="statLabel">Streak</div>
+                  </div>
+                </div>
                 <button id="btnResetStreakTop" class="btn btn-ghost meta-reset" title="Reset streak" type="button">↺</button>
               </div>
               <div id="practiceMetaControls" class="practice-meta-right"></div>


### PR DESCRIPTION
### Motivation
- Make the top-left practice stats (Accuracy / Streak) visually stronger on desktop while keeping labels subtle and preserving the existing green/cream vibe.  
- Add tasteful, non-gamified micro-animations (count-up and streak pulse) that respect `prefers-reduced-motion` and run only when appropriate.  
- Keep changes minimal and local to the stats UI and supporting CSS/JS so mobile and other UI remain unaffected.

### Description
- Replace inline meta text with structured markup (`.statsRow` / `.statPill`) including `statValue`, `statUnit`, `statLabel`, and a subtle flame icon in `index.html`.  
- Add desktop-only styling and responsive adjustments in `css/styles.css` for pill surfaces, typographic hierarchy, hover lift, alignment, and motion-safe pulse animation.  
- Implement `animateNumber()` count-up, session-only first-load guard (`wm_stats_animated`), and streak-increase pulse using previous-streak persistence in `js/mutation-trainer.js`, plus `prefers-reduced-motion` checks and translation/ARIA wiring.  
- Files changed: `index.html`, `css/styles.css`, `js/mutation-trainer.js`.

### Testing
- Started a local dev server with `python -m http.server` which launched successfully.  
- Attempted an automated Playwright screenshot to verify the new UI, but the headless Chromium run failed to launch (Chromium crash), so the screenshot test failed.  
- No unit/integration test suites were run as part of this change.

Short manual test checklist (recommended): load the app at desktop widths (1440px) and confirm bold numbers, subtle labels, hover lift, and a one-time count-up on first load; increase streak to observe a single subtle pulse; toggle language to verify labels update immediately; and check on mobile (e.g. 390px) for no horizontal overflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ad9558448324aef14ffa65398249)