### PR TITLE
Restore compact desktop stats layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -643,61 +643,9 @@ body{
 .practice-meta-left{
   display:flex;
   align-items:center;
-  gap: 0.6rem;
+  gap: 0.45rem;
   color: var(--muted);
   font-size: 0.75rem;
-}
-
-.statsRow{
-  display:flex;
-  gap: 10px;
-  align-items:center;
-}
-
-.statPill{
-  display:flex;
-  flex-direction:column;
-  justify-content:center;
-  padding: 10px 12px;
-  border-radius: 999px;
-  background: rgba(255,255,255,0.65);
-  border: 1px solid rgba(0,0,0,0.06);
-  box-shadow: 0 2px 10px rgba(0,0,0,0.04);
-  min-width: 92px;
-}
-
-.statValue{
-  display:flex;
-  align-items:baseline;
-  gap: 6px;
-  font-weight: 800;
-  font-size: 18px;
-  letter-spacing: -0.01em;
-  color: inherit;
-  line-height: 1.05;
-}
-
-.statUnit{
-  font-size: 12px;
-  font-weight: 700;
-  opacity: 0.75;
-}
-
-.statLabel{
-  margin-top: 2px;
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  opacity: 0.55;
-}
-
-.statIcon{
-  transform: translateY(-1px);
-  opacity: 0.9;
-}
-
-.practice-meta-left .meta-reset{
-  align-self: center;
 }
 
 .practice-meta-left .meta-item{
@@ -740,17 +688,6 @@ body{
   padding: 0.15rem 0.45rem;
   font-size: 0.9rem;
   line-height: 1;
-}
-
-@media (hover:hover){
-  .statPill{
-    transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
-  }
-  .statPill:hover{
-    transform: translateY(-1px);
-    box-shadow: 0 6px 16px rgba(0,0,0,0.08);
-    border-color: rgba(0,0,0,0.10);
-  }
 }
 
 .meta-more-wrap{
@@ -1052,23 +989,7 @@ body{
   }
 }
 
-@media (max-width: 768px){
-  .statPill{
-    padding: 8px 10px;
-    min-width: 78px;
-  }
-  .statValue{
-    font-size: 16px;
-  }
-  .statLabel{
-    font-size: 10px;
-  }
-}
-
 @media (prefers-reduced-motion: reduce){
-  .statPill{
-    transition: none !important;
-  }
   #practiceCard .practice-card-face{
     transition: none;
   }
@@ -1077,18 +998,6 @@ body{
   #practiceCard .practice-card-flip.is-front .practice-card-face.is-back,
   #practiceCard .practice-card-flip.is-back .practice-card-face.is-front{
     transform: none;
-  }
-}
-
-@media (prefers-reduced-motion: no-preference){
-  .pulse{
-    animation: pulsePop 420ms ease-out;
-  }
-
-  @keyframes pulsePop{
-    0%{ transform: scale(1); }
-    40%{ transform: scale(1.06); }
-    100%{ transform: scale(1); }
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -144,21 +144,15 @@
           <div id="practiceHeader" class="practice-header">
             <div id="practiceMetaBar" class="practice-meta-bar">
               <div class="practice-meta-left">
-                <div class="statsRow" aria-label="Stats">
-                  <div class="statPill" id="statAccuracy" aria-label="Accuracy">
-                    <div class="statValue">
-                      <span id="practiceAcc">0</span><span class="statUnit">%</span>
-                    </div>
-                    <div id="practiceAccTitle" class="statLabel">Accuracy</div>
-                  </div>
-                  <div class="statPill" id="statStreak" aria-label="Streak">
-                    <div class="statValue">
-                      <span class="statIcon" aria-hidden="true">🔥</span>
-                      <span id="practiceStreak">0</span>
-                    </div>
-                    <div id="practiceStreakTitle" class="statLabel">Streak</div>
-                  </div>
-                </div>
+                <span class="meta-item meta-accuracy">
+                  <span id="practiceAccTitle" class="meta-label">Accuracy</span>
+                  <span id="practiceAcc" class="meta-value">0%</span>
+                </span>
+                <span class="meta-sep" aria-hidden="true">·</span>
+                <span class="meta-item meta-streak">
+                  <span id="practiceStreakTitle" class="meta-label">Streak</span>
+                  <span class="meta-value"><span aria-hidden="true">🔥</span><span id="practiceStreak">0</span></span>
+                </span>
                 <button id="btnResetStreakTop" class="btn btn-ghost meta-reset" title="Reset streak" type="button">↺</button>
               </div>
               <div id="practiceMetaControls" class="practice-meta-right"></div>


### PR DESCRIPTION
### Motivation

- The recent desktop stats UI changes introduced pill-style markup and animations that caused Accuracy and Streak to stack vertically and lose the compact inline styling. 
- The intent is to restore the previous compact single-line/strip layout for the practice stats without refactoring other code.

### Description

- Replaced the pill-based stats markup in `index.html` with the original inline meta markup using `meta-item` and `meta-sep` so Accuracy and Streak render inline again. 
- Removed the pill styling, hover transitions and pulse animation rules from `css/styles.css` and restored the compact meta spacing and `meta-reset` styling. 
- Adjusted only the styling/markup required to restore the previous layout and preserved other layout code and scripts.
- Files changed: `index.html`, `css/styles.css`.

### Testing

- Launched a local static server with `python -m http.server` to perform a visual check of the restored layout, which started successfully. 
- Attempted an automated visual capture with Playwright, but the Chromium process crashed (SIGSEGV) so the screenshot test failed and could not complete; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b050eb548324b2e3e9a4be0415eb)