### PR TITLE
Emphasize Accuracy/Streak numeric hierarchy

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -661,9 +661,24 @@ body{
   color: rgba(100,116,139,0.85);
 }
 
+.practice-meta-left .statLab{
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
 .practice-meta-left .meta-value{
   font-weight: 600;
   color: rgba(30,41,59,0.82);
+}
+
+.practice-meta-left .statNum{
+  font-weight: 800;
+  font-size: 1.15rem;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: rgba(15,23,42,0.95);
 }
 
 .practice-meta-left .meta-sep{
@@ -893,6 +908,12 @@ body{
     font-size: 0.7rem;
     color: rgba(148,163,184,0.85);
   }
+  .practice-meta-left .statLab{
+    font-size: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    opacity: 1;
+  }
   .practice-meta-left .meta-streak .meta-label{
     display: none;
   }
@@ -900,6 +921,12 @@ body{
     display:inline-flex;
     align-items:center;
     gap: 0.25rem;
+  }
+  .practice-meta-left .statNum{
+    font-size: inherit;
+    letter-spacing: inherit;
+    font-weight: inherit;
+    color: inherit;
   }
   .practice-meta-left .meta-reset{
     display: none;

--- a/index.html
+++ b/index.html
@@ -145,13 +145,13 @@
             <div id="practiceMetaBar" class="practice-meta-bar">
               <div class="practice-meta-left">
                 <span class="meta-item meta-accuracy">
-                  <span id="practiceAccTitle" class="meta-label">Accuracy</span>
-                  <span id="practiceAcc" class="meta-value">0%</span>
+                  <span id="practiceAccTitle" class="meta-label statLab">Accuracy</span>
+                  <span id="practiceAcc" class="meta-value statNum">0%</span>
                 </span>
                 <span class="meta-sep" aria-hidden="true">·</span>
                 <span class="meta-item meta-streak">
-                  <span id="practiceStreakTitle" class="meta-label">Streak</span>
-                  <span class="meta-value"><span aria-hidden="true">🔥</span><span id="practiceStreak">0</span></span>
+                  <span id="practiceStreakTitle" class="meta-label statLab">Streak</span>
+                  <span class="meta-value"><span aria-hidden="true">🔥</span><span id="practiceStreak" class="statNum">0</span></span>
                 </span>
                 <button id="btnResetStreakTop" class="btn btn-ghost meta-reset" title="Reset streak" type="button">↺</button>
               </div>


### PR DESCRIPTION
### Motivation
- Make the Accuracy and Streak numbers visually prominent on desktop while keeping the exact same layout and positions. 
- Preserve subtle, secondary labels and keep the flame icon next to the streak number. 
- Avoid adding animations or changing mobile behavior.

### Description
- Added `statLab` and `statNum` class hooks to the practice header elements: `#practiceAccTitle`, `#practiceAcc`, `#practiceStreakTitle`, and `#practiceStreak` in `index.html`. 
- Introduced desktop CSS rules for `.statLab` and `.statNum` in `css/styles.css` to increase the numeric weight/size and reduce label prominence. 
- Added mobile media-query overrides so the new classes inherit existing mobile sizing and do not alter the mobile layout or stacking. 
- Did not add any hover polish or motion/animation (per requirements) and did not change element structure or positioning beyond adding span/class hooks.

### Testing
- Launched a local dev server with `python -m http.server` and rendered `index.html` at `1280x720`, and captured a screenshot with Playwright to verify the desktop appearance (succeeded). 
- Verified files changed are `index.html` and `css/styles.css` and committed the changes (git commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973825a023c83249a85251b1bac8c1c)