### PR TITLE
Make onboarding visible on mobile with compact card and CTA

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1580,6 +1580,14 @@ body:not(.keyboard-open) .mobile-action-bar{
   font-size: 1rem;
 }
 
+.onboard-card{
+  width: 100%;
+}
+
+.onboard-card-content{
+  width: 100%;
+}
+
 #onboard.onboard-dismissed{
   display: none !important;
 }
@@ -1596,6 +1604,22 @@ body.onboard-modal-open{
 }
 
 @media (max-width: 767px){
+  #onboard{
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+  .onboard-card{
+    border-radius: 1.1rem;
+    padding: 0.85rem;
+    gap: 0.75rem;
+    box-shadow: 0 16px 32px rgba(15,23,42,0.12);
+  }
+  .onboard-card-content{
+    font-size: 0.85rem;
+  }
+  .onboard-card-content .btn-compact{
+    padding: 0.35rem 0.7rem;
+  }
   .onboard-modal-sheet{
     border-radius: 1.5rem 1.5rem 0 0;
   }

--- a/index.html
+++ b/index.html
@@ -53,15 +53,24 @@
     <div id="navbarMount"></div>
 
     <!-- Onboarding -->
-    <section id="onboard" class="max-w-6xl mx-auto p-4 mt-3 hidden md:block">
-      <div class="panel rounded-2xl p-4 flex items-start gap-3">
+    <section id="onboard" class="max-w-6xl mx-auto p-3 md:p-4 mt-2 md:mt-3">
+      <div class="panel onboard-card rounded-2xl p-3 md:p-4 flex items-start gap-3">
         <div class="text-2xl">💡</div>
 
-        <div class="text-sm text-slate-700">
+        <div class="onboard-card-content text-sm text-slate-700">
           <!-- EN -->
           <div data-lang="en">
             <div class="font-medium mb-2">Welcome! Get the most out of the trainer.</div>
-            <div class="space-y-3 leading-relaxed">
+            <div class="md:hidden space-y-2 leading-relaxed">
+              <p>
+                Start with a <b>Quick pack</b> or <b>Filters</b>, then choose <b>Random</b> or <b>Smart</b> mode.
+                Use <b>Hint</b>, <b>Reveal</b>, or <b>Skip</b> to keep moving, and tap <b>Hear</b> to listen.
+              </p>
+              <button type="button" class="btn btn-ghost btn-compact" data-onboard-open aria-haspopup="dialog" aria-controls="onboardModal">
+                Help &amp; tips
+              </button>
+            </div>
+            <div class="hidden md:block space-y-3 leading-relaxed">
               <div>
                 <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">1. Pick a focus fast</div>
                 <p>
@@ -96,7 +105,16 @@
           <!-- CY -->
           <div data-lang="cy">
             <div class="font-medium mb-2">Croeso! Manteisiwch ar yr hyfforddwr.</div>
-            <div class="space-y-3 leading-relaxed">
+            <div class="md:hidden space-y-2 leading-relaxed">
+              <p>
+                Dechreuwch gyda <b>Pecyn cyflym</b> neu <b>Hidlau</b>, yna dewiswch <b>Ar hap</b> neu <b>Clyfar</b>.
+                Defnyddiwch <b>Awgrym</b>, <b>Datgelu</b>, neu <b>Hepgor</b> i gadw i symud ymlaen, a tapiwch <b>Gwrando</b> i wrando.
+              </p>
+              <button type="button" class="btn btn-ghost btn-compact" data-onboard-open aria-haspopup="dialog" aria-controls="onboardModal">
+                Cymorth a chynghorion
+              </button>
+            </div>
+            <div class="hidden md:block space-y-3 leading-relaxed">
               <div>
                 <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">1. Dewiswch ffocws yn gyflym</div>
                 <p>
@@ -128,7 +146,7 @@
             </div>
           </div>
 
-          <div class="mt-3 flex gap-2">
+          <div class="mt-3 flex flex-wrap gap-2">
             <button data-onboard-dismiss class="btn btn-ghost"></button>
           </div>
         </div>

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1360,6 +1360,9 @@ function wireUi() {
   };
 
   $("#onboardHelpBtn")?.addEventListener("click", openOnboardModal);
+  $$("[data-onboard-open]").forEach((btn) => {
+    btn.addEventListener("click", openOnboardModal);
+  });
   $$("[data-onboard-close]").forEach((btn) => {
     btn.addEventListener("click", closeOnboardModal);
   });


### PR DESCRIPTION
### Motivation
- The onboarding panel was hidden on small screens (`hidden md:block`) which prevented mobile users from discovering help and tips quickly.
- Surface a compact, app-like onboarding card on mobile so guidance is visible without opening the filters or extra menus.

### Description
- Updated `index.html` to remove `hidden md:block` and render a compact mobile summary, adding `onboard-card` and `onboard-card-content` wrappers and a mobile `Help & tips` CTA with `data-onboard-open` that targets the existing `#onboardModal`.
- Added mobile-specific onboarding styles in `css/styles.css` (`.onboard-card`, `.onboard-card-content`, and `@media (max-width: 767px)` rules) to keep the card compact, spaced, and app-like without crowding the main view.
- Wired the new CTA to the modal in `js/mutation-trainer.js` by listening for `data-onboard-open` clicks and invoking the existing `openOnboardModal` function.

### Testing
- Launched a static server with `python -m http.server 8000` and captured a headless browser screenshot at `375x812` using Playwright which shows the onboarding card visible on mobile; this test succeeded and produced `artifacts/onboard-mobile.png`.
- Verified the new CTA is bound to `openOnboardModal` via added event listeners in `js/mutation-trainer.js` and did not observe JS errors when loading the page in the automated run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a01036c48324a658970983eab51e)