### PR TITLE
Mobile: show localized “Help” label in header and adjust spacing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -220,7 +220,7 @@ body{
   .header-actions .btn-lang,
   .header-actions .onboard-help-btn{
     height: 2.25rem;
-    padding: 0 0.65rem;
+    padding: 0 0.55rem;
     border-radius: 0.65rem;
     line-height: 1;
   }
@@ -235,7 +235,13 @@ body{
     font-size: 0.7rem;
   }
   .onboard-help-btn{
-    font-size: 0.95rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.9rem;
+  }
+  .onboard-help-label{
+    white-space: nowrap;
   }
   .cymru-red-bar{
     height: 2px;
@@ -1572,12 +1578,23 @@ body:not(.keyboard-open) .mobile-action-bar{
 
 /* ---------- Onboarding help ---------- */
 .onboard-help-btn{
-  width: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   height: 2.25rem;
-  padding: 0;
+  padding: 0 0.65rem;
   border-radius: 999px;
   font-weight: 700;
   font-size: 1rem;
+}
+
+.onboard-help-icon{
+  font-weight: 800;
+  line-height: 1;
+}
+
+.onboard-help-label{
+  line-height: 1;
 }
 
 .onboard-card{

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -14,7 +14,8 @@ import {
   resetFilters,
   hasCustomFilters,
   LABEL,
-  label
+  label,
+  getOnboardHelpLabel
 } from "./state.js";
 import { pickNextSmartIdx } from "./leitner.js";
 import { buildCompleteSentence } from "./tts.js";
@@ -95,8 +96,12 @@ function applyLanguage() {
   });
   const helpBtn = $("#onboardHelpBtn");
   if (helpBtn) {
-    helpBtn.setAttribute("aria-label", LABEL[lang].ui.onboardHelp);
-    helpBtn.setAttribute("title", LABEL[lang].ui.onboardHelp);
+    const helpLabel = getOnboardHelpLabel(lang);
+    helpBtn.setAttribute("aria-label", helpLabel);
+    helpBtn.setAttribute("title", helpLabel);
+    const helpLabelEl = helpBtn.querySelector(".onboard-help-label");
+    if (helpLabelEl) helpLabelEl.textContent = helpLabel;
+    else helpBtn.textContent = helpLabel;
   }
   if ($("#onboardModalTitle")) $("#onboardModalTitle").textContent = LABEL[lang].ui.onboardModalTitle;
   if ($("#onboardModalDesc")) $("#onboardModalDesc").textContent = LABEL[lang].ui.onboardModalDesc;

--- a/js/state.js
+++ b/js/state.js
@@ -381,3 +381,7 @@ export function label(section, key) {
   const lang = state.lang || "en";
   return (LABEL?.[lang]?.[section]?.[key]) || key;
 }
+
+export function getOnboardHelpLabel(lang = state.lang || "en") {
+  return LABEL?.[lang]?.ui?.onboardHelp || "Help";
+}

--- a/nav/navbar.html
+++ b/nav/navbar.html
@@ -21,9 +21,9 @@
         <div class="hidden md:block h-6 w-px bg-slate-200/80"></div>
         <button id="btnLangToggle" class="btn-lang" aria-label="Switch language" title="Switch language"></button>
         <button id="mobileFiltersToggle" class="btn btn-ghost btn-mobile-filters md:hidden" type="button" aria-controls="practiceSidebar" aria-expanded="false">Filters</button>
-        <button id="onboardHelpBtn" class="btn btn-ghost onboard-help-btn md:hidden" type="button" aria-haspopup="dialog" aria-controls="onboardModal" aria-label="More options">
-          <span aria-hidden="true">⋯</span>
-          <span class="sr-only">More</span>
+        <button id="onboardHelpBtn" class="btn btn-ghost onboard-help-btn md:hidden" type="button" aria-haspopup="dialog" aria-controls="onboardModal" aria-label="Help">
+          <span class="onboard-help-icon" aria-hidden="true">?</span>
+          <span class="onboard-help-label">Help</span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Make the mobile header show a clear, visible Help control (not just an ellipsis) that matches the app's localized UI strings. 
- Ensure the visible label and the accessible attributes (`aria-label`/`title`) update when the language toggles.

### Description
- Replace the mobile onboard help button content in `nav/navbar.html` with an icon and a visible `Help` label.  
- Add `getOnboardHelpLabel` in `js/state.js` that returns the localized `LABEL[lang].ui.onboardHelp` string.  
- Update `applyLanguage()` in `js/mutation-trainer.js` to set the help button `aria-label`, `title`, and the visible label text using `getOnboardHelpLabel`.  
- Adjust header/mobile spacing and sizing in `css/styles.css` for `.onboard-help-btn`, and add styling for `.onboard-help-icon` and `.onboard-help-label` so the control fits the header layout on mobile.

### Testing
- Verified label wiring with code search using `rg` to confirm `onboardHelp` is present in `js/state.js` and referenced from `js/mutation-trainer.js`, which succeeded.  
- Started a local server with `python -m http.server 8000` and ran a Playwright script that loaded `index.html` at a mobile viewport (390x844) and produced a screenshot at `artifacts/mobile-help-button.png`, confirming the visible Help control renders on mobile.  
- No automated language-toggle UI test was run, but `applyLanguage()` now updates both the accessible attributes and the visible label so toggling language should display the localized EN/CY text.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a150dc08832484797d6f9d04829d)