### PR TITLE
Add shared scroll-lock utility and use for mobile filters/onboard/report modals

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1616,7 +1616,7 @@ body:not(.keyboard-open) .mobile-action-bar{
   box-shadow: 0 18px 40px rgba(15,23,42,0.16);
 }
 
-body.onboard-modal-open{
+body.scroll-locked{
   overflow: hidden;
 }
 
@@ -1761,9 +1761,6 @@ body.onboard-modal-open{
   }
 }
 
-body.mobile-filters-open{
-  overflow: hidden;
-}
 
 /* =========================================================
    Tailwind utility overrides (KEEP LAST)

--- a/js/card.js
+++ b/js/card.js
@@ -12,6 +12,7 @@ import {
 } from "./state.js";
 import { getCardId, pickNextSmartIdx, updateLeitner } from "./leitner.js";
 import { buildCompleteSentence, playPollySentence } from "./tts.js";
+import { lockScroll, unlockScroll } from "./scroll-lock.js";
 
 const REPORT_ISSUE_BASE_URL = "https://github.com/katyjohannab/mutationtrainer/issues/new";
 
@@ -148,7 +149,7 @@ export function openReportModal(card, cardId) {
 
   modal.classList.remove("hidden");
   modal.setAttribute("aria-hidden", "false");
-  document.body.classList.add("overflow-hidden");
+  lockScroll("report-modal");
   $("#reportDetails")?.focus();
 }
 
@@ -157,7 +158,7 @@ export function closeReportModal() {
   if (!modal) return;
   modal.classList.add("hidden");
   modal.setAttribute("aria-hidden", "true");
-  document.body.classList.remove("overflow-hidden");
+  unlockScroll("report-modal");
 }
 
 export function submitReportIssue(detailsText) {

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -27,6 +27,7 @@ import {
   initCardUi,
   setCardCallbacks
 } from "./card.js";
+import { lockScroll, unlockScroll } from "./scroll-lock.js";
 
 /* ========= Data coercion ========= */
 const PREP = new Set(["am","ar","at","dan","dros","tros","drwy","trwy","gan","heb","hyd","i","o","tan","wrth","yng","yn","gyda","hefo","â"]);
@@ -1314,28 +1315,16 @@ function wireUi() {
 
   initCardUi();
 
-  let mobileFiltersScrollY = 0;
   const setMobileFiltersOpen = (isOpen) => {
     const sidebar = $("#practiceSidebar");
     if (!sidebar) return;
     sidebar.classList.toggle("is-open", isOpen);
-    document.body.classList.toggle("mobile-filters-open", isOpen);
     $("#mobileFiltersToggle")?.setAttribute("aria-expanded", isOpen ? "true" : "false");
     if (isOpen) {
-      mobileFiltersScrollY = window.scrollY;
-      document.body.style.position = "fixed";
-      document.body.style.top = `-${mobileFiltersScrollY}px`;
-      document.body.style.left = "0";
-      document.body.style.right = "0";
-      document.body.style.width = "100%";
+      lockScroll("mobile-filters");
       $(".mobile-filters-body")?.scrollTo({ top: 0 });
     } else {
-      document.body.style.position = "";
-      document.body.style.top = "";
-      document.body.style.left = "";
-      document.body.style.right = "";
-      document.body.style.width = "";
-      window.scrollTo(0, mobileFiltersScrollY);
+      unlockScroll("mobile-filters");
     }
   };
   const bindMobileFiltersToggle = () => {
@@ -1354,14 +1343,14 @@ function wireUi() {
     if (!modal) return;
     modal.classList.remove("hidden");
     modal.setAttribute("aria-hidden", "false");
-    document.body.classList.add("onboard-modal-open");
+    lockScroll("onboard-modal");
   };
   const closeOnboardModal = () => {
     const modal = $("#onboardModal");
     if (!modal) return;
     modal.classList.add("hidden");
     modal.setAttribute("aria-hidden", "true");
-    document.body.classList.remove("onboard-modal-open");
+    unlockScroll("onboard-modal");
   };
 
   $("#onboardHelpBtn")?.addEventListener("click", openOnboardModal);

--- a/js/scroll-lock.js
+++ b/js/scroll-lock.js
@@ -1,0 +1,59 @@
+const scrollLockState = {
+  reasons: new Set(),
+  scrollY: 0,
+  styleCache: null,
+};
+
+function applyLock() {
+  const body = document.body;
+  if (!body) return;
+  scrollLockState.scrollY = window.scrollY || window.pageYOffset || 0;
+  scrollLockState.styleCache = {
+    position: body.style.position,
+    top: body.style.top,
+    left: body.style.left,
+    right: body.style.right,
+    width: body.style.width,
+    overflow: body.style.overflow,
+  };
+  body.classList.add("scroll-locked");
+  body.style.position = "fixed";
+  body.style.top = `-${scrollLockState.scrollY}px`;
+  body.style.left = "0";
+  body.style.right = "0";
+  body.style.width = "100%";
+  body.style.overflow = "hidden";
+}
+
+function releaseLock() {
+  const body = document.body;
+  if (!body) return;
+  const cache = scrollLockState.styleCache || {};
+  body.style.position = cache.position || "";
+  body.style.top = cache.top || "";
+  body.style.left = cache.left || "";
+  body.style.right = cache.right || "";
+  body.style.width = cache.width || "";
+  body.style.overflow = cache.overflow || "";
+  body.classList.remove("scroll-locked");
+  window.scrollTo(0, scrollLockState.scrollY);
+  scrollLockState.styleCache = null;
+}
+
+export function lockScroll(reason = "default") {
+  const key = String(reason || "default");
+  if (scrollLockState.reasons.has(key)) return;
+  scrollLockState.reasons.add(key);
+  if (scrollLockState.reasons.size === 1) {
+    applyLock();
+  }
+}
+
+export function unlockScroll(reason = "default") {
+  const key = String(reason || "default");
+  if (!scrollLockState.reasons.has(key)) return;
+  scrollLockState.reasons.delete(key);
+  if (scrollLockState.reasons.size === 0) {
+    releaseLock();
+  }
+}


### PR DESCRIPTION
### Motivation
- Centralise the page scroll-lock behavior so multiple overlays (mobile filters, onboarding modal, report modal) share a consistent mechanism and cannot leave the body locked if overlays are opened/closed in different orders. 
- Replace ad-hoc `body.style.position/top/left/right/width` mutations and per-overlay body classes with a single reference-counted lock/unlock API. 
- Preserve and restore the page scroll position when overlays are shown/hidden.

### Description
- Add a new `js/scroll-lock.js` that exports `lockScroll(reason)` and `unlockScroll(reason)` and implements reference-counted locking, style caching and scroll-position preservation. 
- Replace inline body style mutations in `js/mutation-trainer.js` for mobile filters (`setMobileFiltersOpen`) to call `lockScroll("mobile-filters")` / `unlockScroll("mobile-filters")`. 
- Switch onboarding modal open/close in `js/mutation-trainer.js` to use `lockScroll("onboard-modal")` / `unlockScroll("onboard-modal")`. 
- Replace report modal body class usage in `js/card.js` with `lockScroll("report-modal")` / `unlockScroll("report-modal")`. 
- Update `css/styles.css` to rely on a single `.scroll-locked` body class (and remove the old ad-hoc body classes for overlays). 
- Files changed: `js/scroll-lock.js` (new), `js/mutation-trainer.js`, `js/card.js`, `css/styles.css`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a3f7fe208324941f621e2c671cd0)