### PR TITLE
Enforce 44px min-height for mobile action buttons

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -219,8 +219,8 @@ body{
   .header-actions .btn,
   .header-actions .btn-lang,
   .header-actions .onboard-help-btn{
-    height: 2.25rem;
-    padding: 0 0.55rem;
+    min-height: 44px;
+    padding: 0 0.5rem;
     border-radius: 0.65rem;
     line-height: 1;
   }
@@ -245,6 +245,27 @@ body{
   }
   .cymru-red-bar{
     height: 2px;
+  }
+}
+
+@media (max-width: 767px){
+  .btn,
+  .btn-compact,
+  .onboard-help-btn,
+  .mobile-filters-close{
+    min-height: 44px;
+  }
+
+  .btn{
+    padding: 0.6rem 1rem;
+  }
+
+  .btn-compact{
+    padding: 0.5rem 0.85rem;
+  }
+
+  .mobile-filters-close{
+    padding: 0.5rem 0.75rem;
   }
 }
 
@@ -1635,7 +1656,7 @@ body.scroll-locked{
     font-size: 0.85rem;
   }
   .onboard-card-content .btn-compact{
-    padding: 0.35rem 0.7rem;
+    padding: 0.5rem 0.85rem;
   }
   .onboard-modal-sheet{
     border-radius: 1.5rem 1.5rem 0 0;


### PR DESCRIPTION
### Motivation
- Improve mobile touch targets by ensuring primary action buttons meet the recommended 44px minimum height for comfortable tapping on small viewports.
- Make header and filter controls consistent so mobile header buttons remain aligned and readable without layout regressions.

### Description
- Set `min-height: 44px` for `.header-actions .btn`, `.header-actions .btn-lang`, and `.header-actions .onboard-help-btn` and tightened their horizontal padding for better compact alignment.
- Added a mobile media block (`@media (max-width: 767px)`) that enforces `min-height: 44px` for `.btn`, `.btn-compact`, `.onboard-help-btn`, and `.mobile-filters-close`, and adjusts padding for `.btn`, `.btn-compact`, and `.mobile-filters-close`.
- Increased onboarding modal compact button padding by updating `.onboard-card-content .btn-compact` to align with the new mobile tap targets.
- Verified `index.html` mobile filter header buttons already use `btn`, `btn-compact`, `mobile-filters-close`, and `btn-primary` classes so the new rules apply without needing template changes.

### Testing
- A local static server was started and a Playwright script captured a screenshot at a 375×812 viewport (`artifacts/mobile-buttons-375.png`), which ran successfully and produced the artifact. 
- The screenshot was used to confirm mobile header buttons are aligned and do not wrap awkwardly at 375px width. 
- No automated failures were observed during the verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973adfb53388324bae2bfddb381a3db)