### PR TITLE
Add mobile layout scaffold for fixed header and bottom bar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -98,6 +98,11 @@ body{
     min-height: 100svh;
     min-height: 100dvh;
   }
+  #app{
+    height: 100dvh;
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 /* ---------- Panels ---------- */
@@ -183,9 +188,12 @@ body{
 }
 
 @media (max-width: 767px){
+  #siteHeader{
+    height: var(--mobile-header-height);
+  }
   .site-header-inner{
     width: 100%;
-    min-height: 52px;
+    min-height: var(--mobile-header-height);
     padding-top: 4px;
     padding-bottom: 4px;
     flex-direction: row;
@@ -1209,6 +1217,7 @@ body{
 :root{
   --keyboard-offset: 0px;
   --mobile-bar-height: 78px;
+  --mobile-header-height: 60px;
 }
 
 .mobile-action-bar{
@@ -1692,8 +1701,12 @@ body.scroll-locked{
     overflow-x: hidden;
   }
   #main{
+    flex: 1 1 auto;
+    overflow-y: auto;
     max-width: 100%;
     width: 100%;
+    min-height: 0;
+    padding-top: var(--mobile-header-height);
     padding-bottom: calc(var(--mobile-bar-height) + env(safe-area-inset-bottom));
   }
   #practiceView,
@@ -1701,6 +1714,10 @@ body.scroll-locked{
     max-width: 100%;
     width: 100%;
     min-width: 0;
+  }
+  #practiceView,
+  #practiceCard{
+    min-height: 0;
   }
   #practiceSidebar{
     position: fixed;


### PR DESCRIPTION
### Motivation
- Provide a mobile-only layout where the header and bottom action bar are fixed and the main content scrolls within the remaining viewport using a single source of truth for heights.
- Ensure practice content does not force viewport-sized containers (no `100vh`-style behavior) so scrolling respects header and bottom padding.

### Description
- Updated `css/styles.css` to set `#app` to a mobile flex scaffold with `height: 100dvh`, `display: flex`, and `flex-direction: column` under `@media (max-width: 767px)`. 
- Introduced the CSS variable `--mobile-header-height` (added alongside `--mobile-bar-height`) and applied it to `#siteHeader` and `.site-header-inner` so header height is a single source of truth on mobile. 
- Made `#main` into the scroll container on mobile by setting `flex: 1 1 auto`, `overflow-y: auto`, `min-height: 0`, and padded it with `padding-top: var(--mobile-header-height)` and `padding-bottom: calc(var(--mobile-bar-height) + env(safe-area-inset-bottom))` so content scrolls inside the visible area. 
- Ensured practice content can shrink inside the scroll container by adding `min-height: 0` to `#practiceView` and `#practiceCard` so they do not force full-viewport height.

### Testing
- Committed the change to Git with the message `Add mobile layout scaffold for app`, and the commit succeeded. 
- Launched a simple HTTP server with `python -m http.server 8000` and ran a Playwright script to render the site at a mobile viewport; the script completed and produced a screenshot artifact `artifacts/mobile-layout.png` confirming the layout renders as expected. 
- No unit tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b1b7e8548324af2cc4d4012c4a6a)