### PR TITLE
Unify mobile header controls with shared .header-btn and sizing tweaks

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -212,6 +212,7 @@ body{
     height: 28px;
     filter: drop-shadow(0 6px 10px rgba(2,6,23,0.12));
     transform: none;
+    align-self: center;
   }
   .brand-title{
     font-size: clamp(1.05rem, 4.2vw, 1.45rem);
@@ -221,14 +222,13 @@ body{
     margin-left: auto;
     gap: 0.5rem;
     flex-wrap: nowrap;
+    align-items: center;
     min-width: 0;
     flex: 0 1 auto;
   }
-  .header-actions .btn,
-  .header-actions .btn-lang,
-  .header-actions .onboard-help-btn{
+  .header-actions .header-btn{
     min-height: 44px;
-    padding: 0 0.5rem;
+    padding: 0 0.55rem;
     border-radius: 0.65rem;
     line-height: 1;
   }
@@ -254,6 +254,12 @@ body{
   .cymru-red-bar{
     height: 2px;
   }
+}
+
+.header-btn{
+  min-height: 2.5rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.7rem;
 }
 
 @media (max-width: 767px){
@@ -569,8 +575,8 @@ body{
   border: 1px solid rgba(15,23,42,0.14);
   color: rgba(15,23,42,0.92);
   box-shadow: 0 1px 3px rgba(0,0,0,0.04);
-  padding: 0.28rem 0.60rem;
-  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.7rem;
   font-weight: 650;
   font-size: 0.78rem;
   line-height: 1;
@@ -1217,7 +1223,7 @@ body{
 :root{
   --keyboard-offset: 0px;
   --mobile-bar-height: 78px;
-  --mobile-header-height: 60px;
+  --mobile-header-height: 54px;
 }
 
 .mobile-action-bar{

--- a/nav/navbar.html
+++ b/nav/navbar.html
@@ -19,9 +19,9 @@
         </nav>
 
         <div class="hidden md:block h-6 w-px bg-slate-200/80"></div>
-        <button id="btnLangToggle" class="btn-lang" aria-label="Switch language" title="Switch language"></button>
-        <button id="mobileFiltersToggle" class="btn btn-ghost btn-mobile-filters md:hidden" type="button" aria-controls="practiceSidebar" aria-expanded="false">Filters</button>
-        <button id="onboardHelpBtn" class="btn btn-ghost onboard-help-btn md:hidden" type="button" aria-haspopup="dialog" aria-controls="onboardModal" aria-label="Help">
+        <button id="btnLangToggle" class="btn-lang header-btn" aria-label="Switch language" title="Switch language"></button>
+        <button id="mobileFiltersToggle" class="btn btn-ghost btn-mobile-filters header-btn md:hidden" type="button" aria-controls="practiceSidebar" aria-expanded="false">Filters</button>
+        <button id="onboardHelpBtn" class="btn btn-ghost onboard-help-btn header-btn md:hidden" type="button" aria-haspopup="dialog" aria-controls="onboardModal" aria-label="Help">
           <span class="onboard-help-icon" aria-hidden="true">?</span>
           <span class="onboard-help-label">Help</span>
         </button>


### PR DESCRIPTION
### Motivation
- Ensure the mobile header stays on a single line with uniformly sized controls and the brand icon aligned to the same baseline as the buttons.
- Make the language toggle visually consistent with other header buttons to avoid a pill-in-pill look and inconsistent heights.

### Description
- Added a shared `header-btn` class to the header buttons in `nav/navbar.html` and applied it to the language toggle, filters button, and help button.
- In `css/styles.css` enforced `flex-wrap: nowrap; align-items: center;` for `.header-actions` in the mobile breakpoint and set `.brand-dragon` to align to center to match the control baseline.
- Introduced a `.header-btn` rule with consistent `min-height`, `padding`, and `border-radius`, and updated `.btn-lang` to adopt the same padding and radius values.
- Tuned the mobile header height variable from `60px` to `54px` to target an overall header height within ~48–56px.

### Testing
- Served the site locally with `python -m http.server 8000` and captured a mobile viewport screenshot using a Playwright script that visited `http://127.0.0.1:8000/index.html` at `390x844`; the script produced `artifacts/mobile-header.png` successfully.
- No automated unit tests were applicable for this static UI change; the visual smoke test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b30425788324b71e70879e5d6275)