### PR TITLE
Unify mobile action bar sizing with shared CSS variables

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1222,7 +1222,9 @@ body{
 
 :root{
   --keyboard-offset: 0px;
-  --mobile-bar-height: 78px;
+  --mobile-bar-height: 88px;
+  --mobile-bar-safe-area: env(safe-area-inset-bottom);
+  --mobile-bar-total: calc(var(--mobile-bar-height) + var(--mobile-bar-safe-area));
   --mobile-header-height: 54px;
 }
 
@@ -1230,8 +1232,8 @@ body{
   z-index: 10030;
   transform: translateY(calc(-1 * var(--keyboard-offset)));
   transition: transform 0.2s ease;
-  height: calc(var(--mobile-bar-height) + env(safe-area-inset-bottom));
-  padding-bottom: env(safe-area-inset-bottom);
+  height: var(--mobile-bar-total);
+  padding-bottom: var(--mobile-bar-safe-area);
   background: rgba(255,255,255,0.92);
   border-top-color: rgba(15,23,42,0.08);
   box-shadow: 0 -3px 10px rgba(15,23,42,0.05);
@@ -1244,9 +1246,11 @@ body:not(.keyboard-open) .mobile-action-bar{
 }
 
 .mobile-action-bar-inner{
-  padding-bottom: 0.5rem;
+  height: var(--mobile-bar-height);
+  padding-bottom: 0;
   width: 100%;
   max-width: 100%;
+  box-sizing: border-box;
 }
 
 .mobile-action-bar .btn{
@@ -1286,10 +1290,10 @@ body:not(.keyboard-open) .mobile-action-bar{
     min-width: 12.5rem;
   }
   #answerBox{
-    scroll-margin-bottom: calc(var(--mobile-bar-height) + env(safe-area-inset-bottom) + var(--keyboard-offset) + 2.5rem);
+    scroll-margin-bottom: calc(var(--mobile-bar-total) + var(--keyboard-offset) + 2.5rem);
   }
   #practiceCard .practice-answerBlock{
-    scroll-margin-bottom: calc(var(--mobile-bar-height) + env(safe-area-inset-bottom) + var(--keyboard-offset) + 2.5rem);
+    scroll-margin-bottom: calc(var(--mobile-bar-total) + var(--keyboard-offset) + 2.5rem);
   }
   .mobile-action-bar-inner{
     gap: 0.35rem;
@@ -1713,7 +1717,7 @@ body.scroll-locked{
     width: 100%;
     min-height: 0;
     padding-top: var(--mobile-header-height);
-    padding-bottom: calc(var(--mobile-bar-height) + env(safe-area-inset-bottom));
+    padding-bottom: var(--mobile-bar-total);
   }
   #practiceView,
   .practice-panel{


### PR DESCRIPTION
### Motivation
- Consolidate mobile action bar sizing into a single source of truth to avoid duplicated calculations and visual mismatch across components.
- Ensure the safe-area inset is applied exactly once and that the action bar inner content does not exceed the visible bar height.

### Description
- Added `--mobile-bar-height: 88px`, `--mobile-bar-safe-area: env(safe-area-inset-bottom)`, and `--mobile-bar-total: calc(var(--mobile-bar-height) + var(--mobile-bar-safe-area))` to `:root` in `css/styles.css`.
- Applied `var(--mobile-bar-total)` to `.mobile-action-bar` `height` and to `#main` `padding-bottom`, and used `var(--mobile-bar-safe-area)` for the bar `padding-bottom` so `env(safe-area-inset-bottom)` appears only once.
- Constrained `.mobile-action-bar-inner` to `height: var(--mobile-bar-height)`, removed its extra bottom padding, and added `box-sizing: border-box` to prevent inner padding from extending beyond the bar.
- Updated `scroll-margin-bottom` for `#answerBox` and `.practice-answerBlock` to use `calc(var(--mobile-bar-total) + var(--keyboard-offset) + 2.5rem)` to keep scroll offsets consistent with the unified bar height.

### Testing
- Started a local server with `python -m http.server 8000` and captured a mobile viewport screenshot using Playwright, which completed successfully.
- Ran repository searches to verify `safe-area-inset-bottom` usage and updated the relevant references, and committed the changes with `git commit`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b41ce0508324bf146b61b5384f38)