### PR TITLE
Adjust mobile filters sheet sizing and scrim behavior

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1745,29 +1745,30 @@ body.scroll-locked{
   .mobile-filters-backdrop{
     position: absolute;
     inset: 0;
+    width: 100%;
+    height: 100%;
     background: rgba(15,23,42,0.45);
     border: 0;
     padding: 0;
+    cursor: pointer;
   }
   .practice-sidebar-sheet{
     position: relative;
     z-index: 1;
     width: 100%;
     max-width: 100%;
-    height: min(100svh, 100dvh);
-    max-height: calc(100svh - var(--keyboard-offset));
+    height: min(95dvh, calc(100dvh - var(--mobile-header-height)));
+    max-height: min(95dvh, calc(100dvh - var(--mobile-header-height) - var(--keyboard-offset)));
     display: flex;
     flex-direction: column;
     overflow: hidden;
     background: #f8fafc;
     border-radius: 1.5rem 1.5rem 0 0;
     box-shadow: 0 -16px 30px rgba(15,23,42,0.18);
-    transform: translateY(8%);
     opacity: 0;
-    transition: transform 0.2s ease, opacity 0.2s ease, max-height 0.2s ease;
+    transition: opacity 0.2s ease, max-height 0.2s ease;
   }
   #practiceSidebar.is-open .practice-sidebar-sheet{
-    transform: translateY(0);
     opacity: 1;
   }
   .mobile-filters-header{


### PR DESCRIPTION
### Motivation

- Ensure the mobile filters sheet sizes correctly against the mobile header and on-screen keyboard so it doesn't bleed offscreen.  
- Remove the partial slide-in translate so the sheet appears consistently when opened while keeping the rounded top corners.  
- Make the scrim cover the full viewport and be clickable to close the sheet.

### Description

- Updated `css/styles.css` to set `.practice-sidebar-sheet` `height` to `min(95dvh, calc(100dvh - var(--mobile-header-height)))` and `max-height` to `min(95dvh, calc(100dvh - var(--mobile-header-height) - var(--keyboard-offset)))`, preserving the rounded top corners and layout.  
- Removed the initial `transform: translateY(8%)` and the `transform` transition so the sheet no longer partially slides in, while keeping the opacity transition.  
- Ensured the scrim (`.mobile-filters-backdrop` / `#mobileFiltersBackdrop`) covers the full screen by adding `width: 100%` and `height: 100%` and made it clickable by adding `cursor: pointer`.

### Testing

- Launched a local HTTP server with `python -m http.server 8000` and executed a Playwright script that opened `http://127.0.0.1:8000/index.html` at a mobile viewport and captured a screenshot; the script completed and produced `artifacts/mobile-filters.png`.  
- The CSS change was committed and no automated failures were reported during the verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b57402a883249618400275042954)