### PR TITLE
Mobile filters header: 3-column layout, compact Apply button, subtle separation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1776,14 +1776,32 @@ body.scroll-locked{
     top: 0;
     background: #f8fafc;
     border-bottom: 1px solid rgba(15,23,42,0.12);
+    box-shadow: 0 1px 0 rgba(15,23,42,0.04);
     padding: 0.65rem 1rem;
     z-index: 3;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.5rem;
   }
   .mobile-filters-close{
     gap: .35rem;
+    justify-self: start;
   }
   .mobile-filters-close-text{
     font-size: .75rem;
+  }
+  .mobile-filters-title{
+    justify-self: center;
+    text-align: center;
+  }
+  .mobile-filters-apply{
+    justify-self: end;
+    padding: 0.35rem 0.65rem;
+    min-height: 1.8rem;
+    font-size: 0.75rem;
+    border-radius: 0.6rem;
+    line-height: 1;
   }
   .mobile-filters-body{
     padding: 0 1rem calc(1.5rem + var(--keyboard-offset));

--- a/index.html
+++ b/index.html
@@ -189,13 +189,13 @@
         <div id="practiceSidebar" class="practice-sidebar md:col-span-1 flex flex-col gap-4">
           <button id="mobileFiltersBackdrop" class="mobile-filters-backdrop md:hidden" type="button" aria-label="Close filters"></button>
           <div class="practice-sidebar-sheet flex flex-col gap-4">
-            <div class="mobile-filters-header md:hidden flex items-center gap-2">
+            <div class="mobile-filters-header md:hidden">
               <button id="mobileFiltersClose" class="btn btn-ghost btn-compact mobile-filters-close" type="button" aria-label="Close filters">
                 <span aria-hidden="true">✕</span>
                 <span class="mobile-filters-close-text">Close</span>
               </button>
-              <span id="mobileFiltersTitle" class="text-sm font-semibold flex-1 text-center">Filters</span>
-              <button id="mobileFiltersApply" class="btn btn-primary btn-compact" type="button">Apply</button>
+              <span id="mobileFiltersTitle" class="mobile-filters-title text-sm font-semibold">Filters</span>
+              <button id="mobileFiltersApply" class="btn btn-primary btn-compact mobile-filters-apply" type="button">Apply</button>
             </div>
             <div class="mobile-filters-body">
               <div id="filtersPanel" class="panel rounded-2xl p-4">


### PR DESCRIPTION
### Motivation
- Make the mobile filters header a clear, three-column bar so the Close control, centered title, and Apply action are visually balanced and remain distinct while scrolling.

### Description
- Updated `index.html` to remove the inline flex wrapper and add semantic hooks: `mobile-filters-title` and `mobile-filters-apply` on the title and Apply button respectively.
- Adjusted `css/styles.css` `.mobile-filters-header` to use a 3-column grid (`grid-template-columns: auto 1fr auto`), added a subtle top shadow/bottom separator, and aligned items with `justify-self` rules.
- Styled the Apply button via `.mobile-filters-apply` for a compact primary appearance with reduced padding/height and a smaller radius so it reads as a compact action.

### Testing
- Launched a local HTTP server with `python -m http.server` and ran a headless Playwright render of the mobile layout, which produced a screenshot artifact successfully after an initial timeout on earlier attempts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b61d80d083248a4a263d8cf834a9)