### PR TITLE
Restructure mobile filter sections into Quick / Core / More details

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -363,8 +363,19 @@ body{
   color: var(--cymru-red-ink);
 }
 
+.filters-section-body{
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .filters-extra{
   margin-top: 0.75rem;
+}
+
+.filters-section-body .filters-extra{
+  margin-top: 0;
 }
 
 .is-hidden{
@@ -1693,6 +1704,10 @@ body.scroll-locked{
     cursor: default;
     list-style: none;
     pointer-events: none;
+  }
+  #filtersPanel #moreFiltersSection > summary{
+    cursor: pointer;
+    pointer-events: auto;
   }
   #filtersPanel details > summary::-webkit-details-marker{
     display: none;

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
 
                   <details id="coreFiltersSection" open>
                     <summary id="coreFiltersSummary" class="cursor-pointer text-sm font-semibold select-none">Core filters</summary>
-                    <div class="mt-3">
+                    <div class="filters-section-body">
                       <div id="coreFiltersHelper" class="text-xs text-slate-500 mb-2"></div>
                       <div id="basicFocus">
                         <div class="grid grid-cols-1 gap-2 text-sm">
@@ -225,9 +225,6 @@
                             <div id="categoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Categories</div>
                             <div id="categoryPills" class="flex flex-wrap gap-1 items-center">
                               <div id="coreCategoryChips" class="pill-group"></div>
-                              <div id="extraCategoryChips" class="pill-group is-hidden"></div>
-                              <div id="allCategoryChips" class="pill-group is-hidden"></div>
-                              <button id="moreFiltersToggle" class="pill pill-more" type="button">More filters</button>
                               <button id="btnFiltersClear" class="pill pill-clear" type="button">
                                 <span class="pill-label">Clear filters</span>
                                 <span class="pill-icon" aria-hidden="true">×</span>
@@ -237,12 +234,22 @@
                         </div>
                       </div>
                     </div>
-                    <div id="moreFiltersPanel" class="filters-extra is-hidden">
-                      <div class="mt-2">
-                        <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
-                        <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
+                  </details>
+
+                  <details id="moreFiltersSection">
+                    <summary id="moreFiltersToggle" class="cursor-pointer text-sm font-semibold select-none">More filters</summary>
+                    <div class="filters-section-body">
+                      <div class="flex flex-wrap gap-1 items-center">
+                        <div id="extraCategoryChips" class="pill-group is-hidden"></div>
+                        <div id="allCategoryChips" class="pill-group is-hidden"></div>
                       </div>
-                      <div class="mt-3 flex flex-wrap gap-1"></div>
+                      <div id="moreFiltersPanel" class="filters-extra is-hidden">
+                        <div class="mt-2">
+                          <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
+                          <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
+                        </div>
+                        <div class="mt-3 flex flex-wrap gap-1"></div>
+                      </div>
                     </div>
                   </details>
                 </div>

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -991,6 +991,7 @@ function buildFilters() {
   const moreFiltersPanel = $("#moreFiltersPanel");
   const moreFiltersToggle = $("#moreFiltersToggle");
   const allCategoryChips = $("#allCategoryChips");
+  const moreFiltersSection = $("#moreFiltersSection");
   const setMoreFiltersOpen = (isOpen, { save = false } = {}) => {
     if (moreFiltersPanel) {
       moreFiltersPanel.classList.toggle("is-hidden", !isOpen);
@@ -1003,6 +1004,9 @@ function buildFilters() {
       moreFiltersToggle.textContent = isOpen
         ? LABEL[lang].ui.advancedFiltersOpen
         : LABEL[lang].ui.advancedFiltersClosed;
+    }
+    if (moreFiltersSection) {
+      moreFiltersSection.open = isOpen;
     }
     if (save) {
       state.showMoreFilters = isOpen;


### PR DESCRIPTION
### Motivation
- Improve mobile filters UX by grouping related controls into collapsible `details` panels for faster scanning and clearer hierarchy.
- Preserve existing filter IDs so existing filter logic and bindings remain unchanged while relocating markup and adjusting spacing.

### Description
- Reorganized the mobile filters markup in `index.html` into three `details` sections: `#quickPacksSection` (open), `#coreFiltersSection` (open) and `#moreFiltersSection` (closed) and moved `#extraCategoryChips`, `#allCategoryChips` and `#moreFiltersPanel` (including `#triggerFilter`) into the new `#moreFiltersSection` while keeping the same element IDs.
- Replaced the inline category/spacing wrapper for core filters with a new `.filters-section-body` wrapper and moved the `More filters` summary to the `details` header so it is a native disclosure on mobile.
- Added small CSS helpers in `css/styles.css` (`.filters-section-body` and a rule to make `#moreFiltersSection > summary` interactive on desktop) to control spacing and keep the advanced panel visually consistent.
- Synced the `details` open state with existing logic by exposing `#moreFiltersSection` in `js/mutation-trainer.js` and setting `moreFiltersSection.open = isOpen` inside the existing `setMoreFiltersOpen` helper so the UI reflects `state.showMoreFilters`.

### Testing
- Served the site locally with `python -m http.server 8000` to exercise the static files and confirmed the server started successfully.
- Performed static verification using `rg`/`sed`/`nl` to confirm the relocated DOM nodes and CSS rules are present and that `js/mutation-trainer.js` was updated to toggle `moreFiltersSection.open`, and these inspections succeeded.
- Attempted an automated visual smoke test with Playwright to capture the mobile filters view, but the Playwright run timed out waiting for the dynamic navbar mount (`#navbarMount`) so the screenshot step failed; the underlying DOM/CSS/JS changes remain implemented and the JS state sync logic was added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b77cab7083249d4fbb28a0e25f0c)