### PR TITLE
Improve pill and preset tap targets and prevent horizontal overflow

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -80,6 +80,10 @@ body{
   --chip-fg:#065f46;
 
   --focus:rgba(4,120,87,0.35);
+
+  --tap-target-min-height: 2.5rem;
+  --tap-target-pad-y: 0.45rem;
+  --tap-target-pad-x: 0.75rem;
 }
 
 /* ---------- Page background ---------- */
@@ -317,17 +321,32 @@ body{
   align-items:center;
   gap:.35rem;
   border-radius:999px;
-  padding:.28rem .56rem;
+  padding:var(--tap-target-pad-y) var(--tap-target-pad-x);
+  min-height:var(--tap-target-min-height);
   font-weight:650;
   font-size:10px;
   border:1px solid rgba(148,163,184,.28);
   background:rgba(255,255,255,.82);
   cursor:pointer;
   transition: transform .08s ease, box-shadow .12s ease, background .12s ease, border-color .12s ease;
+  max-width:100%;
+  white-space:normal;
+  word-break:break-word;
 }
 
 .pill-group{
   display: contents;
+}
+
+#categoryPills,
+#familyBtns,
+#moreFiltersSection .filters-section-body > .flex{
+  display:flex;
+  flex-wrap:wrap;
+  gap:0.35rem;
+  align-items:center;
+  overflow-x:hidden;
+  max-width:100%;
 }
 
 .pill-core{
@@ -414,13 +433,16 @@ body{
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  padding: 1rem;
+  padding: var(--tap-target-pad-y) var(--tap-target-pad-x);
+  min-height: var(--tap-target-min-height);
   border-radius: 0.75rem;
   background: #ffffff;
   border: 1px solid rgba(148,163,184,0.35);
   box-shadow: 0 10px 20px rgba(15,23,42,0.08), inset 0 1px 0 rgba(255,255,255,0.9);
   transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
   position: relative;
+  max-width: 100%;
+  white-space: normal;
 }
 
 .preset-btn:hover {


### PR DESCRIPTION
### Motivation
- Make `.pill` and `.preset-btn` use consistent tap-target sizing and ensure long labels wrap or truncate cleanly to avoid horizontal overflow in chip rows.

### Description
- Introduce shared sizing tokens `--tap-target-min-height`, `--tap-target-pad-y`, and `--tap-target-pad-x` in `:root` and apply them to `.pill` and `.preset-btn` to standardize `padding` and `min-height`.
- Allow long labels to wrap by adding `max-width: 100%`, `white-space: normal`, and `word-break: break-word` to pills and `max-width: 100%`/`white-space: normal` to preset buttons.
- Replace margin-based spacing for chip rows with gap-based flex layout by making `#categoryPills`, `#familyBtns`, and `#moreFiltersSection .filters-section-body > .flex` use `display:flex`, `flex-wrap:wrap`, `gap`, `overflow-x:hidden`, and `max-width:100%` to eliminate horizontal scroll.

### Testing
- Launched a local dev server with `python -m http.server 8000` and captured a visual snapshot using Playwright to verify pill/preset layout and wrapping; the screenshot artifact was produced successfully.
- Performed selector inspection to confirm the new CSS rules target the intended chip and preset areas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ba98f0d08324a481753a9f98a1d7)