### PR TITLE
Refine practice header metadata strip

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -701,11 +701,11 @@ body{
 
 .practice-meta-bar{
   display:flex;
-  align-items:center;
+  align-items:flex-start;
   justify-content: space-between;
   gap: 0.85rem;
   margin-bottom: 0.4rem;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 
 .practice-header{
@@ -717,9 +717,10 @@ body{
 .practice-meta-left{
   display:flex;
   align-items:center;
-  gap: 0.45rem;
-  color: var(--muted);
-  font-size: 0.75rem;
+  gap: 0.4rem;
+  color: rgba(100,116,139,0.85);
+  font-size: 0.78rem;
+  flex-wrap: wrap;
 }
 
 .practice-meta-left .meta-item{
@@ -744,15 +745,15 @@ body{
 
 .practice-meta-left .meta-value{
   font-weight: 600;
-  color: rgba(30,41,59,0.82);
+  color: rgba(51,65,85,0.9);
 }
 
 .practice-meta-left .statNum{
-  font-weight: 800;
-  font-size: 1.15rem;
-  letter-spacing: -0.02em;
-  line-height: 1;
-  color: rgba(15,23,42,0.95);
+  font-weight: 600;
+  font-size: 0.8rem;
+  letter-spacing: 0.01em;
+  line-height: 1.1;
+  color: rgba(51,65,85,0.9);
 }
 
 .practice-meta-left .meta-sep{
@@ -763,6 +764,12 @@ body{
   padding: 0.1rem 0.35rem;
   font-size: 0.7rem;
   color: rgba(100,116,139,0.7);
+}
+
+.practice-meta-summary .practice-progress-line{
+  margin: 0;
+  font-size: inherit;
+  color: inherit;
 }
 
 .practice-meta-right{
@@ -851,7 +858,7 @@ body{
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  margin-bottom: 1.1rem;
+  margin-bottom: 0.9rem;
 }
 
 .practice-progress-line{

--- a/index.html
+++ b/index.html
@@ -161,14 +161,16 @@
           <!-- Slim meta bar (Ticket 2.1) -->
           <div id="practiceHeader" class="practice-header">
             <div id="practiceMetaBar" class="practice-meta-bar">
-              <div class="practice-meta-left">
+              <div class="practice-meta-left practice-meta-summary">
+                <span id="practiceProgressLine" class="practice-progress-line"></span>
+                <span class="meta-sep" aria-hidden="true">·</span>
                 <span class="meta-item meta-accuracy">
-                  <span id="practiceAccTitle" class="meta-label statLab">Accuracy</span>
+                  <span id="practiceAccTitle" class="meta-label statLab sr-only">Accuracy</span>
                   <span id="practiceAcc" class="meta-value statNum">0%</span>
                 </span>
                 <span class="meta-sep" aria-hidden="true">·</span>
                 <span class="meta-item meta-streak">
-                  <span id="practiceStreakTitle" class="meta-label statLab">Streak</span>
+                  <span id="practiceStreakTitle" class="meta-label statLab sr-only">Streak</span>
                   <span class="meta-value"><span aria-hidden="true">🔥</span><span id="practiceStreak" class="statNum">0</span></span>
                 </span>
                 <button id="btnResetStreakTop" class="btn btn-ghost meta-reset" title="Reset streak" type="button">↺</button>
@@ -176,7 +178,6 @@
               <div id="practiceMetaControls" class="practice-meta-right"></div>
             </div>
             <div id="practiceProgress" class="practice-progress" aria-live="polite">
-              <div id="practiceProgressLine" class="practice-progress-line"></div>
               <div id="practiceProgressBar" class="practice-progress-bar" aria-hidden="true">
                 <div id="practiceProgressBarFill" class="practice-progress-bar-fill"></div>
               </div>

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -302,8 +302,7 @@ function updateProgressLine({ currentIndex, totalCards }) {
   if (!lineEl) return;
   const safeCurrent = Number.isFinite(currentIndex) ? currentIndex : 0;
   const safeTotal = Number.isFinite(totalCards) ? totalCards : 0;
-  const activeFilterLabel = LABEL?.[lang]?.ui?.activeFilterLabel || (lang === "cy" ? "Hidl actif" : "Active Filter");
-  lineEl.textContent = `${activeFilterLabel}: ${getProgressFocusLabel()} · ${safeCurrent}/${safeTotal}`;
+  lineEl.textContent = `${getProgressFocusLabel()} · ${safeCurrent}/${safeTotal}`;
   const barFill = $("#practiceProgressBarFill");
   if (barFill) {
     const pct = safeTotal > 0 ? Math.min((safeCurrent / safeTotal) * 100, 100) : 0;


### PR DESCRIPTION
### Motivation
- Combine progress, accuracy and streak into a single low-contrast inline metadata strip to reduce visual weight and match the requested compact layout.
- Keep the `Random/Smart` segmented control compact and adjacent to the strip while avoiding card-like styling for the metadata area.

### Description
- Moved the progress label (`#practiceProgressLine`) into the metadata left area and combined it with accuracy and streak in `index.html`, and made the visible labels screen-reader-only (`sr-only`).
- Adjusted styles in `css/styles.css` to make `.practice-meta-bar` wrap-friendly, reduce contrast and sizes of metadata text, and ensure the strip appears as lightweight inline metadata rather than a card.
- Simplified the progress text in `js/mutation-trainer.js` by removing the extra `Active Filter` prefix so the line now renders as `Focus · current/total`.

### Testing
- Launched a local static server with `python -m http.server` and captured a visual snapshot via a Playwright script, which completed successfully and produced `artifacts/practice-meta-strip.png`.
- No automated unit tests were run for these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bcf70b688324b85879e703756cc4)