### PR TITLE
Segmented EN/CY language toggle in header

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -243,9 +243,6 @@ body{
   .btn-lang{
     font-size: 0.7rem;
   }
-  .langtag{
-    font-size: 0.7rem;
-  }
   .onboard-help-btn{
     display: inline-flex;
     align-items: center;
@@ -603,13 +600,11 @@ body{
 .btn-lang{
   display:inline-flex;
   align-items:center;
-  gap:0.45rem;
+  gap:0.5rem;
   background: rgba(255,255,255,0.86);
   border: 1px solid rgba(15,23,42,0.14);
   color: rgba(15,23,42,0.92);
   box-shadow: 0 1px 3px rgba(0,0,0,0.04);
-  padding: 0.45rem 0.85rem;
-  border-radius: 0.7rem;
   font-weight: 650;
   font-size: 0.78rem;
   line-height: 1;
@@ -626,17 +621,34 @@ body{
   transform: translateY(-1px);
   box-shadow: 0 6px 14px rgba(2,6,23,0.08);
 }
-/* Make the inner "CY/EN" a label, not a second pill */
-.langtag{
-  border: 0;
+.lang-icon{
+  font-size: 0.9rem;
+  line-height: 1;
+}
+.lang-seg{
+  display:inline-flex;
+  align-items:center;
+  gap:0.2rem;
+  padding:0.12rem;
+  border-radius:0.6rem;
+  border:1px solid rgba(148,163,184,0.45);
+  background: rgba(248,250,252,0.9);
+}
+.lang-seg-btn{
+  border-radius:0.5rem;
+  padding:0.22rem 0.5rem;
+  font-size:0.7rem;
+  font-weight:700;
+  letter-spacing:0.1em;
+  text-transform:uppercase;
+  color: rgba(15,23,42,0.7);
   background: transparent;
-  padding: 0;
-  min-width: auto;
-  border-radius: 0;
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  color: rgba(15,23,42,0.80);
+  transition: transform .06s ease, background .12s ease, color .12s ease, box-shadow .12s ease;
+}
+.lang-seg-btn.is-on{
+  color:#fff;
+  background: linear-gradient(135deg, var(--primary-from) 0%, var(--primary-mid) 45%, var(--primary-to) 100%);
+  box-shadow: 0 6px 12px rgba(2,6,23,0.14), inset 0 1px 0 rgba(255,255,255,0.2);
 }
 
 /* ---------- Segmented control (Random / Smart) ---------- */

--- a/nav/navbar.html
+++ b/nav/navbar.html
@@ -19,7 +19,13 @@
         </nav>
 
         <div class="hidden md:block h-6 w-px bg-slate-200/80"></div>
-        <button id="btnLangToggle" class="btn-lang header-btn" aria-label="Switch language" title="Switch language"></button>
+        <button id="btnLangToggle" class="btn-lang header-btn" aria-label="Switch language" title="Switch language">
+          <span class="lang-icon" aria-hidden="true">🌐</span>
+          <span class="lang-seg" aria-hidden="true">
+            <span class="lang-seg-btn is-on">EN</span>
+            <span class="lang-seg-btn">CY</span>
+          </span>
+        </button>
         <button id="mobileFiltersToggle" class="btn btn-ghost btn-mobile-filters header-btn md:hidden" type="button" aria-controls="practiceSidebar" aria-expanded="false">Filters</button>
         <button id="onboardHelpBtn" class="btn btn-ghost onboard-help-btn header-btn md:hidden" type="button" aria-haspopup="dialog" aria-controls="onboardModal" aria-label="Help">
           <span class="onboard-help-icon" aria-hidden="true">?</span>

--- a/nav/navbar.js
+++ b/nav/navbar.js
@@ -54,9 +54,14 @@
     const btn = document.getElementById("btnLangToggle");
     if (!btn) return;
     const lang = wmGetLang();
-    const current = (lang === "en") ? "EN" : "CY";
-    const next = (lang === "en") ? "CY" : "EN";
-    btn.innerHTML = `<span aria-hidden="true">🌐</span><span class="langtag">${current}→${next}</span>`;
+    const isEnglish = lang === "en";
+    btn.innerHTML = `
+      <span class="lang-icon" aria-hidden="true">🌐</span>
+      <span class="lang-seg" aria-hidden="true">
+        <span class="lang-seg-btn ${isEnglish ? "is-on" : ""}">EN</span>
+        <span class="lang-seg-btn ${isEnglish ? "" : "is-on"}">CY</span>
+      </span>
+    `;
     btn.title = (lang === "en") ? "Switch language from English to Cymraeg" : "Switch language from Cymraeg to English";
     btn.setAttribute("aria-label", (lang === "en") ? "Switch language from English to Cymraeg" : "Switch language from Cymraeg to English");
   }


### PR DESCRIPTION
### Motivation
- Replace the single `.btn-lang` label with a visually clear segmented control so language selection mirrors other header actions while preserving the existing toggle behavior.
- Keep the single root button used by `wmBindLangToggle` so existing click/toggle logic and accessibility attributes remain unchanged.

### Description
- Replaced the empty `#btnLangToggle` content with a segmented control markup (`.lang-icon` + `.lang-seg` with two `.lang-seg-btn` children) in `nav/navbar.html` and kept the button as the single click target via `id="btnLangToggle"`.
- Updated `wmSyncLangToggleUI` in `nav/navbar.js` to render the segmented markup dynamically and apply the `is-on` class to the active language so the UI reflects `wmGetLang()`.
- Added styling in `css/styles.css` for `.lang-icon`, `.lang-seg`, and `.lang-seg-btn` and adjusted `.btn-lang` spacing so the control matches the height, padding, and visual treatment of other header buttons.

### Testing
- Launched a local HTTP server and ran a Playwright script to load `index.html` and capture a screenshot, which completed successfully and produced `artifacts/navbar-lang-toggle.png`.
- Verified the changes were staged and committed successfully with `git` (commit message: "Update language toggle segmented control").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973be10eb8483249e48d6c31028de67)