### PR TITLE
Add shell mobile filters toggle fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,9 @@
 
     <!-- Main panels -->
     <main id="main" class="practice-layout grow max-w-6xl mx-auto p-4 pb-24 md:pb-4">
+      <div class="md:hidden flex justify-end mb-2">
+        <button id="mobileFiltersToggleShell" class="btn btn-ghost btn-compact" type="button" aria-expanded="false" aria-controls="practiceSidebar">Filters</button>
+      </div>
       <div id="practiceView" class="grid md:grid-cols-3 gap-4 items-start">
         <!-- Left: practice card -->
         <div class="practice-panel md:col-span-2 panel rounded-2xl p-6 md:p-7">

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -158,6 +158,7 @@ function applyLanguage() {
   if ($("#statsAccTitle")) $("#statsAccTitle").textContent = LABEL[lang].ui.statsAccuracyTitle;
   if ($("#statsByOutcomeTitle")) $("#statsByOutcomeTitle").textContent = LABEL[lang].ui.statsByOutcomeTitle;
   if ($("#mobileFiltersToggle")) $("#mobileFiltersToggle").textContent = LABEL[lang].ui.filtersToggle;
+  if ($("#mobileFiltersToggleShell")) $("#mobileFiltersToggleShell").textContent = LABEL[lang].ui.filtersToggle;
   if ($("#mobileFiltersApply")) $("#mobileFiltersApply").textContent = LABEL[lang].ui.filtersApply;
   if ($("#mobileFiltersTitle")) $("#mobileFiltersTitle").textContent = LABEL[lang].ui.filtersTitle;
   if ($("#mbCheck")) $("#mbCheck").textContent = LABEL[lang].check;
@@ -1318,11 +1319,14 @@ function wireUi() {
 
   initCardUi();
 
+  const getMobileFiltersToggles = () => [$("#mobileFiltersToggle"), $("#mobileFiltersToggleShell")].filter(Boolean);
   const setMobileFiltersOpen = (isOpen) => {
     const sidebar = $("#practiceSidebar");
     if (!sidebar) return;
     sidebar.classList.toggle("is-open", isOpen);
-    $("#mobileFiltersToggle")?.setAttribute("aria-expanded", isOpen ? "true" : "false");
+    getMobileFiltersToggles().forEach((toggle) => {
+      toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+    });
     if (isOpen) {
       lockScroll("mobile-filters");
       $(".mobile-filters-body")?.scrollTo({ top: 0 });
@@ -1331,12 +1335,13 @@ function wireUi() {
     }
   };
   const bindMobileFiltersToggle = () => {
-    const toggle = $("#mobileFiltersToggle");
-    if (!toggle || toggle.dataset.wmBound === "1") return;
-    toggle.dataset.wmBound = "1";
-    toggle.addEventListener("click", () => {
-      const isOpen = $("#practiceSidebar")?.classList.contains("is-open");
-      setMobileFiltersOpen(!isOpen);
+    getMobileFiltersToggles().forEach((toggle) => {
+      if (toggle.dataset.wmBound === "1") return;
+      toggle.dataset.wmBound = "1";
+      toggle.addEventListener("click", () => {
+        const isOpen = $("#practiceSidebar")?.classList.contains("is-open");
+        setMobileFiltersOpen(!isOpen);
+      });
     });
   };
 


### PR DESCRIPTION
### Motivation
- Ensure mobile users have a Filters toggle even if the external navbar fails to load by adding an in-shell, mobile-only toggle that mirrors navbar behavior.

### Description
- Added a mobile-only button `#mobileFiltersToggleShell` inside `index.html` to appear on small screens as a fallback toggle.
- Synced the shell toggle label in `applyLanguage()` by setting `#mobileFiltersToggleShell` text to `LABEL[lang].ui.filtersToggle`.
- Introduced `getMobileFiltersToggles()` and updated `setMobileFiltersOpen()` in `js/mutation-trainer.js` to update `aria-expanded` on all toggles and reuse the same open/close logic.
- Updated `bindMobileFiltersToggle()` to attach click listeners to both the navbar toggle and the new shell toggle so they share behavior.

### Testing
- Launched a local static server with `python -m http.server 8000` and used a Playwright script to load `http://localhost:8000/index.html` at a mobile viewport, which completed and produced a screenshot artifact `artifacts/mobile-filters-toggle.png` showing the new button.
- No unit tests were added; the change is a small UI wiring update and the end-to-end screenshot validated the presence and interaction target of the fallback toggle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bed01bec83249f890257556b4106)