### PR TITLE
Make mobile filters sheet full-height, top-aligned and suppress header when open

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1789,8 +1789,8 @@ body.scroll-locked{
     position: fixed;
     inset: 0;
     display: none;
-    align-items: flex-end;
-    justify-content: center;
+    align-items: stretch;
+    justify-content: flex-start;
     padding: 0;
     z-index: 10040;
     max-width: 100vw;
@@ -1809,12 +1809,16 @@ body.scroll-locked{
     cursor: pointer;
   }
   .practice-sidebar-sheet{
-    position: relative;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
     z-index: 1;
     width: 100%;
     max-width: 100%;
-    height: min(95dvh, calc(100dvh - var(--mobile-header-height)));
-    max-height: min(95dvh, calc(100dvh - var(--mobile-header-height) - var(--keyboard-offset)));
+    height: 100dvh;
+    max-height: 100dvh;
+    padding-top: env(safe-area-inset-top);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -1826,6 +1830,12 @@ body.scroll-locked{
   }
   #practiceSidebar.is-open .practice-sidebar-sheet{
     opacity: 1;
+  }
+  body.mobile-filters-open #siteHeader{
+    display: none;
+  }
+  body.mobile-filters-open #main{
+    padding-top: 0;
   }
   .mobile-filters-header{
     position: sticky;

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1324,6 +1324,7 @@ function wireUi() {
     const sidebar = $("#practiceSidebar");
     if (!sidebar) return;
     sidebar.classList.toggle("is-open", isOpen);
+    document.body.classList.toggle("mobile-filters-open", isOpen);
     getMobileFiltersToggles().forEach((toggle) => {
       toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
     });
@@ -1332,6 +1333,7 @@ function wireUi() {
       $(".mobile-filters-body")?.scrollTo({ top: 0 });
     } else {
       unlockScroll("mobile-filters");
+      $(".mobile-filters-body")?.scrollTo({ top: 0 });
     }
   };
   const bindMobileFiltersToggle = () => {


### PR DESCRIPTION
### Motivation
- Prevent the mobile filters sheet from overlapping the navbar by making it a full-height, top-aligned modal that respects safe-area insets and by providing a way to suppress the site header while the sheet is open.

### Description
- Update `css/styles.css` to change `#practiceSidebar` alignment and make `.practice-sidebar-sheet` `position: absolute` with `top: 0`, `height: 100dvh`, `max-height: 100dvh`, and `padding-top: env(safe-area-inset-top)`.
- Add `body.mobile-filters-open` rules to hide `#siteHeader` and remove the `#main` top padding while the filters modal is open to avoid overlap with the navbar.
- Keep the header inside the sheet sticky and ensure only `.mobile-filters-body` scrolls so close/apply controls remain visible, preserving existing `.mobile-filters-actions` behavior.
- Update `js/mutation-trainer.js` `setMobileFiltersOpen` to toggle the `mobile-filters-open` class on `document.body` and to reset the `.mobile-filters-body` scroll position when opening or closing while continuing to call `lockScroll`/`unlockScroll`.

### Testing
- Started a local server with `python -m http.server 8000`, which launched successfully.
- Ran a Playwright click-flow test that attempted to click the UI toggle but timed out waiting for the toggle (test failed), then ran a DOM-injection Playwright script that added the open class and captured a screenshot successfully producing `artifacts/mobile-filters.png` (test succeeded).
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c1541bc88324be5cfc958274bdc0)