### PR TITLE
Refactor More filters toggle to button and centralize state handling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1742,13 +1742,7 @@ body.scroll-locked{
     overscroll-behavior: contain;
   }
   #filtersPanel details > summary{
-    cursor: default;
     list-style: none;
-    pointer-events: none;
-  }
-  #filtersPanel #moreFiltersSection > summary{
-    cursor: pointer;
-    pointer-events: auto;
   }
   #filtersPanel details > summary::-webkit-details-marker{
     display: none;
@@ -1759,6 +1753,16 @@ body.scroll-locked{
     border-radius: 999px;
     border: 3px solid rgba(255,255,255,0.70);
   }
+}
+
+#moreFiltersToggle{
+  background: transparent;
+  border: 0;
+  padding: 0;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  color: inherit;
 }
 
 @media (max-width: 767px){

--- a/index.html
+++ b/index.html
@@ -240,8 +240,10 @@
                     </div>
                   </details>
 
-                  <details id="moreFiltersSection">
-                    <summary id="moreFiltersToggle" class="cursor-pointer text-sm font-semibold select-none">More filters</summary>
+                  <section id="moreFiltersSection">
+                    <button id="moreFiltersToggle" class="cursor-pointer text-sm font-semibold select-none" type="button" aria-expanded="false" aria-controls="allCategoryChips moreFiltersPanel">
+                      More filters
+                    </button>
                     <div class="filters-section-body">
                       <div class="flex flex-wrap gap-1 items-center">
                         <div id="extraCategoryChips" class="pill-group is-hidden"></div>
@@ -255,7 +257,7 @@
                         <div class="mt-3 flex flex-wrap gap-1"></div>
                       </div>
                     </div>
-                  </details>
+                  </section>
                 </div>
               </div>
             </div>

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -991,8 +991,8 @@ function buildFilters() {
   const moreFiltersPanel = $("#moreFiltersPanel");
   const moreFiltersToggle = $("#moreFiltersToggle");
   const allCategoryChips = $("#allCategoryChips");
-  const moreFiltersSection = $("#moreFiltersSection");
   const setMoreFiltersOpen = (isOpen, { save = false } = {}) => {
+    state.showMoreFilters = isOpen;
     if (moreFiltersPanel) {
       moreFiltersPanel.classList.toggle("is-hidden", !isOpen);
     }
@@ -1005,11 +1005,7 @@ function buildFilters() {
         ? LABEL[lang].ui.advancedFiltersOpen
         : LABEL[lang].ui.advancedFiltersClosed;
     }
-    if (moreFiltersSection) {
-      moreFiltersSection.open = isOpen;
-    }
     if (save) {
-      state.showMoreFilters = isOpen;
       saveLS("wm_show_more_filters", state.showMoreFilters);
     }
   };


### PR DESCRIPTION
### Motivation

- Remove reliance on the native `<details>`/`<summary>` disclosure for the “More filters” control so the UI can be toggled consistently across desktop and mobile.
- Fix desktop CSS that disabled pointer events for filter summaries which blocked programmatic toggle handling and made the control inconsistent.
- Make `buildFilters` the single source of truth for the More filters open state so `aria-expanded`, `state.showMoreFilters`, and visibility classes stay in sync.

### Description

- Replaced the `<details id="moreFiltersSection">` / `<summary id="moreFiltersToggle">` with a semantic `<section id="moreFiltersSection">` and a `button` with `id="moreFiltersToggle"`, keeping `#moreFiltersPanel` and `#allCategoryChips` inside the section in `index.html`.
- Removed the desktop rule that suppressed pointer events for `#filtersPanel details > summary` and added styling for `#moreFiltersToggle` in `css/styles.css` so the new button is visually neutral and full-width.
- In `js/mutation-trainer.js` (in `buildFilters`) made `setMoreFiltersOpen` the authoritative updater by immediately setting `state.showMoreFilters`, toggling `is-hidden` classes, and updating `aria-expanded` and the toggle label; removed reliance on `details.open` and kept the `_wmBound` guard to bind the click handler once.

### Testing

- Ran a local HTTP server with `python -m http.server 8000` and executed a Playwright smoke script that navigated to `http://127.0.0.1:8000/index.html`, clicked `#moreFiltersToggle`, and captured a screenshot; the script completed and the screenshot artifact was produced successfully.
- Verified that the toggle updates `aria-expanded` and shows/hides `#moreFiltersPanel` and `#allCategoryChips` after clicking the button via the automated interaction, and the event binding guard prevents duplicate handlers during rebuilds.
- No unit tests were added or run for this change beyond the browser smoke test described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c21d75bc83248afacc777bc4b0b7)