### PR TITLE
Refine pill styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -316,9 +316,11 @@ body{
 .pill{
   display:inline-flex;
   align-items:center;
+  justify-content:center;
   gap:.35rem;
-  border-radius:999px;
+  border-radius:0.85rem;
   padding:var(--tap-target-pad-y) var(--tap-target-pad-x);
+  min-width:2.5rem;
   min-height:var(--tap-target-min-height);
   font-weight:650;
   font-size:10px;
@@ -359,7 +361,7 @@ body{
 }
 
 .pill-more{
-  font-weight: 700;
+  font-weight: 650;
   border-style: dashed;
   background: rgba(241,245,249,.95);
   color: #0f172a;
@@ -373,7 +375,7 @@ body{
 }
 
 .pill-clear{
-  font-weight: 700;
+  font-weight: 650;
   border-color: transparent;
   background: rgba(185,28,28,0.08);
   color: var(--cymru-red-ink);


### PR DESCRIPTION
### Motivation
- Ensure pill-like controls keep a consistent rounded silhouette for very short labels while maintaining visual balance across variants after changing the shape.

### Description
- Modify `css/styles.css` to update the `.pill` rule with `border-radius: 0.85rem`, `min-width: 2.5rem`, and `justify-content: center`, and reduce the font weight on `.pill-more` and `.pill-clear` to `650` to rebalance visual weight.

### Testing
- Performed a visual smoke test by serving the site with `python -m http.server 8000` and running a Playwright script to capture `artifacts/pills-update.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c33ae0288324ba40366bbfbac6f1)