### PR TITLE
Refine mobile header buttons: consistent sizing, subtle outline, and icon+label filters

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -232,13 +232,27 @@ body{
   }
   .header-actions .header-btn{
     min-height: 44px;
-    padding: 0 0.55rem;
-    border-radius: 0.65rem;
+    padding: 0 0.7rem;
+    border-radius: 0.6rem;
+    font-size: 0.82rem;
     line-height: 1;
+    background: rgba(248,250,252,0.9);
+    border: 1px solid rgba(148,163,184,0.45);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.75);
   }
   .btn-mobile-filters{
-    font-size: 0.85rem;
-    line-height: 1.1;
+    min-height: 44px;
+    padding: 0 0.7rem;
+    border-radius: 0.6rem;
+    font-size: 0.82rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .btn-mobile-filters .btn-icon{
+    font-size: 1rem;
+    line-height: 1;
   }
   .btn-lang{
     font-size: 0.7rem;

--- a/index.html
+++ b/index.html
@@ -156,7 +156,10 @@
     <!-- Main panels -->
     <main id="main" class="practice-layout grow max-w-6xl mx-auto p-4 pb-24 md:pb-4">
       <div class="md:hidden flex justify-end mb-2">
-        <button id="mobileFiltersToggleShell" class="btn btn-ghost btn-compact" type="button" aria-expanded="false" aria-controls="practiceSidebar">Filters</button>
+        <button id="mobileFiltersToggleShell" class="btn btn-ghost btn-compact btn-mobile-filters" type="button" aria-expanded="false" aria-controls="practiceSidebar">
+          <span class="btn-icon" aria-hidden="true">🎛️</span>
+          <span class="btn-label">Filters</span>
+        </button>
       </div>
       <div id="practiceView" class="grid md:grid-cols-3 gap-4 items-start">
         <!-- Left: practice card -->

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -77,6 +77,16 @@ function coerceRow(row) {
   };
 }
 
+function setButtonLabel(el, text) {
+  if (!el) return;
+  const labelEl = el.querySelector(".btn-label");
+  if (labelEl) {
+    labelEl.textContent = text;
+    return;
+  }
+  el.textContent = text;
+}
+
 /* IMPORTANT: This does NOT toggle the navbar. navbar.js owns that.
    This only updates dynamic UI and labels to match state.lang. */
 function applyLanguage() {
@@ -157,8 +167,8 @@ function applyLanguage() {
   if ($("#moreInfoSummary")) $("#moreInfoSummary").textContent = LABEL[lang].ui.moreInfo;
   if ($("#statsAccTitle")) $("#statsAccTitle").textContent = LABEL[lang].ui.statsAccuracyTitle;
   if ($("#statsByOutcomeTitle")) $("#statsByOutcomeTitle").textContent = LABEL[lang].ui.statsByOutcomeTitle;
-  if ($("#mobileFiltersToggle")) $("#mobileFiltersToggle").textContent = LABEL[lang].ui.filtersToggle;
-  if ($("#mobileFiltersToggleShell")) $("#mobileFiltersToggleShell").textContent = LABEL[lang].ui.filtersToggle;
+  setButtonLabel($("#mobileFiltersToggle"), LABEL[lang].ui.filtersToggle);
+  setButtonLabel($("#mobileFiltersToggleShell"), LABEL[lang].ui.filtersToggle);
   if ($("#mobileFiltersApply")) $("#mobileFiltersApply").textContent = LABEL[lang].ui.filtersApply;
   if ($("#mobileFiltersTitle")) $("#mobileFiltersTitle").textContent = LABEL[lang].ui.filtersTitle;
   if ($("#mbCheck")) $("#mbCheck").textContent = LABEL[lang].check;

--- a/nav/navbar.html
+++ b/nav/navbar.html
@@ -26,7 +26,10 @@
             <span class="lang-seg-btn">CY</span>
           </span>
         </button>
-        <button id="mobileFiltersToggle" class="btn btn-ghost btn-mobile-filters header-btn md:hidden" type="button" aria-controls="practiceSidebar" aria-expanded="false">Filters</button>
+        <button id="mobileFiltersToggle" class="btn btn-ghost btn-mobile-filters header-btn md:hidden" type="button" aria-controls="practiceSidebar" aria-expanded="false">
+          <span class="btn-icon" aria-hidden="true">🎛️</span>
+          <span class="btn-label">Filters</span>
+        </button>
         <button id="onboardHelpBtn" class="btn btn-ghost onboard-help-btn header-btn md:hidden" type="button" aria-haspopup="dialog" aria-controls="onboardModal" aria-label="Help">
           <span class="onboard-help-icon" aria-hidden="true">?</span>
           <span class="onboard-help-label">Help</span>


### PR DESCRIPTION
### Motivation
- Improve mobile header touch targets and visual clarity by aligning button height, font-size, and padding for a more app-like header experience.
- Distinguish header controls from the header surface with a subtle outline/background and reduced corner radius to match pill styling.
- Make the mobile filters trigger clearer by converting it to an icon+label layout while preserving localized text.

### Description
- Adjusted `.header-actions .header-btn` and `.btn-mobile-filters` in `css/styles.css` to use `min-height: 44px`, consistent padding, `font-size: 0.82rem`, reduced `border-radius`, and a light background/border for separation from the header.
- Made `.btn-mobile-filters` an inline-flex element with improved icon spacing and added a `.btn-icon` rule to size the icon consistently.
- Updated `nav/navbar.html` and `index.html` to add `span` elements for `.btn-icon` and `.btn-label` inside mobile filters buttons to provide an inline icon+label layout.
- Added `setButtonLabel` to `js/mutation-trainer.js` and switched mobile-filters label updates to call it so localization preserves the icon+label markup.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright script that loaded `http://127.0.0.1:8000/index.html` at a mobile viewport and saved a screenshot to `artifacts/mobile-header.png`, which completed successfully.
- The page load and screenshot run via Playwright exited without errors, confirming the updated markup renders at the target mobile size.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c3e529a08324817f585efa849e15)