### PR TITLE
Compact mobile header and restore mobile filter toggle behaviour

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -198,8 +198,8 @@ body{
   .site-header-inner{
     width: 100%;
     min-height: var(--mobile-header-height);
-    padding-top: 4px;
-    padding-bottom: 4px;
+    padding-top: 2px;
+    padding-bottom: 2px;
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
@@ -224,27 +224,27 @@ body{
   }
   .header-actions{
     margin-left: auto;
-    gap: 0.5rem;
+    gap: 0.35rem;
     flex-wrap: nowrap;
     align-items: center;
     min-width: 0;
     flex: 0 1 auto;
   }
   .header-actions .header-btn{
-    min-height: 44px;
-    padding: 0 0.7rem;
-    border-radius: 0.6rem;
-    font-size: 0.82rem;
+    min-height: 34px;
+    padding: 0 0.5rem;
+    border-radius: 0.5rem;
+    font-size: 0.78rem;
     line-height: 1;
-    background: rgba(248,250,252,0.9);
-    border: 1px solid rgba(148,163,184,0.45);
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.75);
+    background: transparent;
+    border: 0;
+    box-shadow: none;
   }
   .btn-mobile-filters{
-    min-height: 44px;
-    padding: 0 0.7rem;
-    border-radius: 0.6rem;
-    font-size: 0.82rem;
+    min-height: 34px;
+    padding: 0 0.5rem;
+    border-radius: 0.5rem;
+    font-size: 0.78rem;
     line-height: 1;
     display: inline-flex;
     align-items: center;
@@ -256,6 +256,20 @@ body{
   }
   .btn-lang{
     font-size: 0.7rem;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    padding: 0 0.35rem;
+  }
+  .lang-seg{
+    border: 0;
+    background: rgba(15,23,42,0.08);
+    padding: 0.08rem;
+  }
+  .lang-seg-btn{
+    padding: 0.18rem 0.35rem;
+    font-size: 0.65rem;
+    letter-spacing: 0.06em;
   }
   .onboard-help-btn{
     display: inline-flex;
@@ -352,8 +366,7 @@ body{
 }
 
 #categoryPills,
-#familyBtns,
-#moreFiltersSection .filters-section-body > .flex{
+#familyBtns{
   display:flex;
   flex-wrap:wrap;
   gap:0.35rem;
@@ -1293,7 +1306,7 @@ body{
   --mobile-bar-height: 88px;
   --mobile-bar-safe-area: env(safe-area-inset-bottom);
   --mobile-bar-total: calc(var(--mobile-bar-height) + var(--mobile-bar-safe-area));
-  --mobile-header-height: 54px;
+  --mobile-header-height: 48px;
 }
 
 .mobile-action-bar{
@@ -1772,13 +1785,17 @@ body.scroll-locked{
 }
 
 #moreFiltersToggle{
-  background: transparent;
-  border: 0;
-  padding: 0;
+  white-space: nowrap;
+}
+
+.more-filters-inline{
   width: 100%;
-  text-align: left;
-  font: inherit;
-  color: inherit;
+  flex: 1 1 100%;
+}
+
+.more-filters-inline .filters-extra{
+  width: 100%;
+  flex: 1 1 100%;
 }
 
 @media (max-width: 767px){
@@ -1786,14 +1803,19 @@ body.scroll-locked{
   #app{
     overflow-x: hidden;
   }
+  :root{
+    --tap-target-min-height: 2.1rem;
+    --tap-target-pad-y: 0.25rem;
+    --tap-target-pad-x: 0.5rem;
+  }
   #main{
     flex: 1 1 auto;
-    overflow-y: auto;
     max-width: 100%;
     width: 100%;
-    min-height: 0;
-    padding-top: var(--mobile-header-height);
     padding-bottom: var(--mobile-bar-total);
+  }
+  .pill{
+    font-size: 0.65rem;
   }
   #practiceView,
   .practice-panel{
@@ -1857,18 +1879,31 @@ body.scroll-locked{
   body.mobile-filters-open #main{
     padding-top: 0;
   }
+  body.mobile-filters-open{
+    overflow: hidden;
+  }
   .mobile-filters-header{
     position: sticky;
     top: 0;
     background: #f8fafc;
     border-bottom: 1px solid rgba(15,23,42,0.12);
     box-shadow: 0 1px 0 rgba(15,23,42,0.04);
-    padding: 0.65rem 1rem;
+    padding: 1.4rem 1rem 0.75rem;
     z-index: 3;
     display: grid;
     grid-template-columns: auto 1fr auto;
     align-items: center;
     gap: 0.5rem;
+  }
+  .mobile-filters-handle{
+    position: absolute;
+    top: 0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 2.6rem;
+    height: 0.3rem;
+    border-radius: 999px;
+    background: rgba(148,163,184,0.7);
   }
   .mobile-filters-close{
     gap: .35rem;
@@ -1903,6 +1938,11 @@ body.scroll-locked{
   }
   #filtersPanel{
     width: 100%;
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0;
   }
   .mobile-filters-actions{
     flex: 0 0 auto;

--- a/index.html
+++ b/index.html
@@ -155,12 +155,6 @@
 
     <!-- Main panels -->
     <main id="main" class="practice-layout grow max-w-6xl mx-auto p-4 pb-24 md:pb-4">
-      <div class="md:hidden flex justify-end mb-2">
-        <button id="mobileFiltersToggleShell" class="btn btn-ghost btn-compact btn-mobile-filters" type="button" aria-expanded="false" aria-controls="practiceSidebar">
-          <span class="btn-icon" aria-hidden="true">🎛️</span>
-          <span class="btn-label">Filters</span>
-        </button>
-      </div>
       <div id="practiceView" class="grid md:grid-cols-3 gap-4 items-start">
         <!-- Left: practice card -->
         <div class="practice-panel md:col-span-2 panel rounded-2xl p-6 md:p-7">
@@ -197,6 +191,7 @@
           <button id="mobileFiltersBackdrop" class="mobile-filters-backdrop md:hidden" type="button" aria-label="Close filters"></button>
           <div class="practice-sidebar-sheet flex flex-col gap-4">
             <div class="mobile-filters-header md:hidden">
+              <div class="mobile-filters-handle" aria-hidden="true"></div>
               <button id="mobileFiltersClose" class="btn btn-ghost btn-compact mobile-filters-close" type="button" aria-label="Close filters">
                 <span aria-hidden="true">✕</span>
                 <span class="mobile-filters-close-text">Close</span>
@@ -232,6 +227,21 @@
                             <div id="categoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Categories</div>
                             <div id="categoryPills" class="flex flex-wrap gap-1 items-center">
                               <div id="coreCategoryChips" class="pill-group"></div>
+                              <button id="moreFiltersToggle" class="pill pill-more" type="button" aria-expanded="false" aria-controls="moreFiltersInline">
+                                <span class="pill-label">More filters</span>
+                                <span class="pill-icon" aria-hidden="true">▾</span>
+                              </button>
+                              <div id="moreFiltersInline" class="more-filters-inline flex flex-wrap gap-1 items-center">
+                                <div id="extraCategoryChips" class="pill-group is-hidden"></div>
+                                <div id="allCategoryChips" class="pill-group is-hidden"></div>
+                                <div id="moreFiltersPanel" class="filters-extra is-hidden">
+                                  <div class="mt-2">
+                                    <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
+                                    <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
+                                  </div>
+                                  <div class="mt-3 flex flex-wrap gap-1"></div>
+                                </div>
+                              </div>
                               <button id="btnFiltersClear" class="pill pill-clear" type="button">
                                 <span class="pill-label">Clear filters</span>
                                 <span class="pill-icon" aria-hidden="true">×</span>
@@ -243,24 +253,7 @@
                     </div>
                   </details>
 
-                  <section id="moreFiltersSection">
-                    <button id="moreFiltersToggle" class="cursor-pointer text-sm font-semibold select-none" type="button" aria-expanded="false" aria-controls="allCategoryChips moreFiltersPanel">
-                      More filters
-                    </button>
-                    <div class="filters-section-body">
-                      <div class="flex flex-wrap gap-1 items-center">
-                        <div id="extraCategoryChips" class="pill-group is-hidden"></div>
-                        <div id="allCategoryChips" class="pill-group is-hidden"></div>
-                      </div>
-                      <div id="moreFiltersPanel" class="filters-extra is-hidden">
-                        <div class="mt-2">
-                          <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
-                          <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
-                        </div>
-                        <div class="mt-3 flex flex-wrap gap-1"></div>
-                      </div>
-                    </div>
-                  </section>
+                  <section id="moreFiltersSection" class="hidden"></section>
                 </div>
               </div>
             </div>

--- a/js/card.js
+++ b/js/card.js
@@ -375,7 +375,7 @@ export function renderPractice() {
   }
 
   const summary = document.createElement("div");
-  summary.className = "practice-filter-summary flex flex-wrap items-center gap-2 mb-4";
+  summary.className = "practice-filter-summary hidden md:flex flex-wrap items-center gap-2 mb-4";
 
   const addChip = (text, onClear) => {
     const c = document.createElement("button");

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -139,9 +139,15 @@ function applyLanguage() {
   }
   const moreFiltersToggle = $("#moreFiltersToggle");
   if (moreFiltersToggle) {
-    moreFiltersToggle.textContent = state.showMoreFilters
+    const label = state.showMoreFilters
       ? LABEL[lang].ui.advancedFiltersOpen
       : LABEL[lang].ui.advancedFiltersClosed;
+    const icon = state.showMoreFilters ? "▴" : "▾";
+    const labelEl = moreFiltersToggle.querySelector(".pill-label");
+    const iconEl = moreFiltersToggle.querySelector(".pill-icon");
+    if (labelEl) labelEl.textContent = label;
+    if (iconEl) iconEl.textContent = icon;
+    if (!labelEl && !iconEl) moreFiltersToggle.textContent = `${label} ${icon}`;
   }
   if ($("#mobileClearFocus")) $("#mobileClearFocus").textContent = LABEL[lang].ui.clearFocus;
   if ($("#mobileClearFilters")) $("#mobileClearFilters").textContent = LABEL[lang].ui.clearFilters;
@@ -168,7 +174,6 @@ function applyLanguage() {
   if ($("#statsAccTitle")) $("#statsAccTitle").textContent = LABEL[lang].ui.statsAccuracyTitle;
   if ($("#statsByOutcomeTitle")) $("#statsByOutcomeTitle").textContent = LABEL[lang].ui.statsByOutcomeTitle;
   setButtonLabel($("#mobileFiltersToggle"), LABEL[lang].ui.filtersToggle);
-  setButtonLabel($("#mobileFiltersToggleShell"), LABEL[lang].ui.filtersToggle);
   if ($("#mobileFiltersApply")) $("#mobileFiltersApply").textContent = LABEL[lang].ui.filtersApply;
   if ($("#mobileFiltersTitle")) $("#mobileFiltersTitle").textContent = LABEL[lang].ui.filtersTitle;
   if ($("#mbCheck")) $("#mbCheck").textContent = LABEL[lang].check;
@@ -1001,6 +1006,7 @@ function buildFilters() {
   const moreFiltersPanel = $("#moreFiltersPanel");
   const moreFiltersToggle = $("#moreFiltersToggle");
   const allCategoryChips = $("#allCategoryChips");
+  const extraCategoryChips = $("#extraCategoryChips");
   const setMoreFiltersOpen = (isOpen, { save = false } = {}) => {
     state.showMoreFilters = isOpen;
     if (moreFiltersPanel) {
@@ -1009,11 +1015,20 @@ function buildFilters() {
     if (allCategoryChips) {
       allCategoryChips.classList.toggle("is-hidden", !isOpen);
     }
+    if (extraCategoryChips) {
+      extraCategoryChips.classList.toggle("is-hidden", !isOpen);
+    }
     if (moreFiltersToggle) {
       moreFiltersToggle.setAttribute("aria-expanded", String(isOpen));
-      moreFiltersToggle.textContent = isOpen
+      const label = isOpen
         ? LABEL[lang].ui.advancedFiltersOpen
         : LABEL[lang].ui.advancedFiltersClosed;
+      const icon = isOpen ? "▴" : "▾";
+      const labelEl = moreFiltersToggle.querySelector(".pill-label");
+      const iconEl = moreFiltersToggle.querySelector(".pill-icon");
+      if (labelEl) labelEl.textContent = label;
+      if (iconEl) iconEl.textContent = icon;
+      if (!labelEl && !iconEl) moreFiltersToggle.textContent = `${label} ${icon}`;
     }
     if (save) {
       saveLS("wm_show_more_filters", state.showMoreFilters);
@@ -1325,7 +1340,7 @@ function wireUi() {
 
   initCardUi();
 
-  const getMobileFiltersToggles = () => [$("#mobileFiltersToggle"), $("#mobileFiltersToggleShell")].filter(Boolean);
+  const getMobileFiltersToggles = () => [$("#mobileFiltersToggle")].filter(Boolean);
   const setMobileFiltersOpen = (isOpen) => {
     const sidebar = $("#practiceSidebar");
     if (!sidebar) return;
@@ -1334,24 +1349,14 @@ function wireUi() {
     getMobileFiltersToggles().forEach((toggle) => {
       toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
     });
-    if (isOpen) {
-      lockScroll("mobile-filters");
-      $(".mobile-filters-body")?.scrollTo({ top: 0 });
-    } else {
-      unlockScroll("mobile-filters");
-      $(".mobile-filters-body")?.scrollTo({ top: 0 });
-    }
+    $(".mobile-filters-body")?.scrollTo({ top: 0 });
   };
-  const bindMobileFiltersToggle = () => {
-    getMobileFiltersToggles().forEach((toggle) => {
-      if (toggle.dataset.wmBound === "1") return;
-      toggle.dataset.wmBound = "1";
-      toggle.addEventListener("click", () => {
-        const isOpen = $("#practiceSidebar")?.classList.contains("is-open");
-        setMobileFiltersOpen(!isOpen);
-      });
-    });
-  };
+  document.addEventListener("click", (event) => {
+    const toggle = event.target?.closest?.("#mobileFiltersToggle");
+    if (!toggle) return;
+    const isOpen = $("#practiceSidebar")?.classList.contains("is-open");
+    setMobileFiltersOpen(!isOpen);
+  });
 
   applyOnboardDismissedState();
   const openOnboardModal = () => {
@@ -1445,8 +1450,6 @@ function wireUi() {
   $("#mbSkip")?.addEventListener("click", () => $("#btnSkip")?.click());
   $("#mbNext")?.addEventListener("click", () => nextCard(1));
 
-  bindMobileFiltersToggle();
-  document.addEventListener("wm:navbar-ready", bindMobileFiltersToggle);
   $("#mobileFiltersApply")?.addEventListener("click", () => setMobileFiltersOpen(false));
   $("#mobileFiltersClose")?.addEventListener("click", () => setMobileFiltersOpen(false));
   $("#mobileFiltersBackdrop")?.addEventListener("click", () => setMobileFiltersOpen(false));


### PR DESCRIPTION
### Motivation
- Restore a compact, inline mobile navbar and pill appearance, reduce oversized paddings and borders, and fix mobile filter UX so the filter control works and doesn’t force extra scrolling. 
- Make the mobile filters sheet behave like a native control (visual handle, transparent sheet) and prevent background scrolling when it’s open.

### Description
- CSS: reduced `--mobile-header-height` to `48px`, tightened `.site-header-inner` paddings, shrank `.header-actions` buttons and `.btn-mobile-filters`, removed heavy borders/backgrounds from header controls, adjusted `.btn-lang`/`.lang-seg` sizing, lowered mobile tap-target variables, reduced `.pill` font/spacing, made `#filtersPanel` transparent and added a `.mobile-filters-handle`, and prevent background scroll with `body.mobile-filters-open { overflow: hidden }` in mobile rules. 
- HTML: moved the "More filters" control inline into the category pill row and added `#moreFiltersToggle`, `#moreFiltersInline`, `#extraCategoryChips`, `#allCategoryChips`, and `#moreFiltersPanel` structures while hiding the old `#moreFiltersSection`. 
- JS: made the mobile filters toggle reliable by delegating clicks on `#mobileFiltersToggle` with `document.addEventListener('click', ...)` so it works after the async navbar injection and removed the redundant shell toggle; synced inline more-toggle label/icon and show/hide logic to update `.pill-label`/`.pill-icon`; and hid the active-filter summary on small screens by switching to `hidden md:flex` in `js/card.js`.

### Testing
- Launched a local static server with `python -m http.server 8000` to serve the app, which started successfully. 
- Attempted an automated mobile UI check with Playwright to open `http://127.0.0.1:8000/index.html`, click `#mobileFiltersToggle` and capture a screenshot, but the Playwright run timed out and failed. 
- No unit or integration test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c5a95ae08324baa13305c937b587)