### PR TITLE
Fix mobile filters drawer sizing and viewport metrics

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1836,6 +1836,8 @@ body.scroll-locked{
     padding: 0;
     z-index: 10040;
     max-width: 100vw;
+    height: calc(var(--viewport-height, 100svh) - var(--mobile-bar-total));
+    max-height: calc(var(--viewport-height, 100lvh) - var(--mobile-bar-total));
   }
   #practiceSidebar.is-open{
     display: flex;
@@ -1858,12 +1860,12 @@ body.scroll-locked{
     z-index: 1;
     width: 100%;
     max-width: 100%;
-    height: 100dvh;
-    max-height: 100dvh;
+    height: calc(var(--viewport-height, 100svh) - var(--mobile-bar-total));
+    max-height: 100%;
     padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
     display: flex;
     flex-direction: column;
-    overflow: hidden;
     background: #f8fafc;
     border-radius: 1.5rem 1.5rem 0 0;
     box-shadow: 0 -16px 30px rgba(15,23,42,0.18);

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1269,6 +1269,8 @@ function updateViewportMetrics() {
       || active.tagName === "TEXTAREA"
       || active.isContentEditable);
   const effectiveOffset = isTyping ? keyboardOffset : 0;
+  const viewportHeight = vv?.height || window.innerHeight;
+  document.documentElement.style.setProperty("--viewport-height", `${viewportHeight}px`);
   document.documentElement.style.setProperty("--keyboard-offset", `${effectiveOffset}px`);
   document.body.classList.toggle("keyboard-open", effectiveOffset > 0);
 }
@@ -1349,7 +1351,6 @@ function wireUi() {
     getMobileFiltersToggles().forEach((toggle) => {
       toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
     });
-    $(".mobile-filters-body")?.scrollTo({ top: 0 });
   };
   document.addEventListener("click", (event) => {
     const toggle = event.target?.closest?.("#mobileFiltersToggle");


### PR DESCRIPTION
### Motivation

- The mobile filters drawer was sized to full viewport (`100dvh`) and collided with the fixed bottom action bar, hid controls under safe-area insets, and forced awkward page scrolling. The visual viewport height wasn't used by CSS, causing layout glitches when the address bar or keyboard changed the viewport.

### Description

- Change sizing of `#practiceSidebar` and `.practice-sidebar-sheet` to subtract the mobile action bar by using `calc(var(--viewport-height, 100svh) - var(--mobile-bar-total))` and constrain `max-height` so the sheet never sits under the bottom bar.
- Add `padding-bottom: env(safe-area-inset-bottom)` to `.practice-sidebar-sheet` so controls are not overlapped on devices with notches and allow internal scrolling via `.mobile-filters-body` (no overflow:hidden on the sheet).
- Track the visual viewport height in `updateViewportMetrics()` by setting `--viewport-height` from `window.visualViewport.height` and continue to set `--keyboard-offset` for keyboard-aware padding.
- Remove the forced `scrollTo({ top: 0 })` call when opening the mobile filters so the sheet relies on internal scrolling and doesn’t jump the page.

### Testing

- Started a local HTTP server and ran a Playwright script that opened `index.html` at a mobile viewport (`390x844`), triggered the filters toggle, and captured a screenshot; the script completed successfully and produced `artifacts/mobile-filters.png` showing the sheet positioned above the bottom bar.
- No unit tests exist for this UI change; the automated visual interaction (Playwright) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973cb37bcd48324bddadaafd4d67a85)