### PR TITLE
Fix navbar header overflow and refine language toggle styles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -158,11 +158,11 @@ body{
 .brand-title{
   display:flex;
   align-items:center;
-  line-height:1;
+  line-height:1.1;
   white-space:nowrap;
   min-width: 0;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  text-overflow: initial;
+  overflow: visible;
 }
 .title-hy{ color:var(--emerald-ink); }
 .title-trei{ color:var(--cymru-red-ink); margin-left:.06em; }
@@ -638,11 +638,17 @@ body{
   border: 1px solid rgba(15,23,42,0.16);
   background: rgba(255,255,255,0.9);
   color: rgba(15,23,42,0.9);
-  font-size: 0.78rem;
+  font-size: 0.85rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  min-width: 3.1rem;
+  min-width: 2.6rem;
+  min-height: 2.3rem;
+  padding: 0 0.75rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .header-actions-lang .btn:hover{
   background: rgba(255,255,255,1);
@@ -655,6 +661,19 @@ body{
   border-color: rgba(6,78,59,0.4);
   background: linear-gradient(135deg, var(--primary-from) 0%, var(--primary-mid) 45%, var(--primary-to) 100%);
   box-shadow: 0 8px 16px rgba(2,6,23,0.14), inset 0 1px 0 rgba(255,255,255,0.2);
+}
+
+@media (min-width: 768px){
+  .header-actions{
+    width: auto;
+    flex: 0 0 auto;
+  }
+  .brand-lockup{
+    flex: 1 1 auto;
+  }
+  .brand-title{
+    white-space: normal;
+  }
 }
 
 /* ---------- Segmented control (Random / Smart) ---------- */


### PR DESCRIPTION
### Motivation
- The site header was clipping the brand title on desktop and the language toggle buttons had awkward sizing and spacing, breaking the navbar layout.
- Header action elements could steal horizontal space at larger breakpoints, preventing the title from rendering fully.

### Description
- Updated `.brand-title` to use `line-height: 1.1`, `text-overflow: initial`, and `overflow: visible` so the brand text is not clipped and can size correctly.
- Refined the language toggles under `.header-actions-lang .btn` by increasing `font-size`, reducing `letter-spacing`, and adding `min-height`, `padding`, `border-radius`, and `inline-flex` alignment for a cleaner, centered appearance.
- Added a desktop media query (`@media (min-width: 768px)`) to keep `.header-actions` from expanding and to let the `.brand-lockup` and `.brand-title` take the available space so the title can wrap normally.

### Testing
- Started a local HTTP server with `python -m http.server 8000` and rendered `index.html` to confirm visual behavior, which loaded successfully.
- Captured a verification screenshot using Playwright (artifact `artifacts/navbar-fix.png`) to inspect the header layout, and the script completed successfully.
- No automated unit tests were required for these static CSS changes and visual checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d00f8f088324ad134857bdd91a63)