### PR TITLE
Add mobile layout contract documentation

### DIFF
--- a/docs/mobile-layout-contract.md
+++ b/docs/mobile-layout-contract.md
@@ -1,0 +1,41 @@
+# Mobile Layout Contract
+
+## Purpose
+This document defines the required mobile layout behavior for the filters drawer, header controls, pills, and safe-area handling. It is a contract for implementation and QA on small screens.
+
+## Required behavior: mobile filters drawer
+- **Open:** Tapping the mobile filters toggle must open the drawer and set `aria-expanded="true"` on the toggle.
+- **Close:** The drawer must close via (a) the close button, (b) tapping the backdrop, and (c) pressing **Escape**. Closing returns focus to the toggle when possible.
+- **Backdrop:** The backdrop must cover the viewport and block interaction with background content.
+- **Focus trap:** When open, focus must be trapped within the drawer until it closes.
+- **Scroll lock:** Background scroll must be prevented while the drawer is open.
+- **Internal scroll:** The drawer body must scroll internally when content exceeds available height.
+- **Mobile-only overlay:** The drawer must behave as an overlay (not in-flow), anchored to the viewport.
+
+## Required layout: mobile header controls
+- **No wrap chaos:** Mobile header controls (language toggle + filters toggle + help) must not wrap into multiple rows on typical phone widths.
+- **Order:** Language toggles remain grouped; the filters toggle and help button remain aligned in the header control row.
+- **Hit targets:** Minimum tap target height is 44px, while maintaining compact spacing.
+
+## Required pill sizing (density)
+- **Pill padding targets:**
+  - Vertical padding: **4px** (0.25rem).
+  - Horizontal padding: **8px** (0.5rem).
+- **Font size target:** ~**0.65rem** on mobile to match the current compact density.
+- **No chunky pills:** Avoid large padding or oversized border radius increases on mobile.
+
+## Required safe-area rules
+- Drawer and mobile action bars must respect device safe areas:
+  - Use `env(safe-area-inset-top)` for top padding as needed.
+  - Use `env(safe-area-inset-bottom)` for bottom padding on the drawer and fixed mobile action bars.
+- Mobile layouts must account for the combined safe-area + fixed action bar height when setting drawer height.
+
+## Definition of Done (manual)
+- [ ] Mobile filters toggle opens the drawer and sets `aria-expanded="true"`.
+- [ ] Close works via X button, backdrop tap, and **Escape**.
+- [ ] Focus remains trapped inside the drawer when open.
+- [ ] Background scroll is prevented while the drawer is open.
+- [ ] Drawer body scrolls independently when content is long.
+- [ ] Header controls remain on one line without wrapping on common phone widths.
+- [ ] Pills match compact padding targets (4px vertical / 8px horizontal).
+- [ ] Safe-area padding is applied to drawer and fixed action bars.


### PR DESCRIPTION
### Motivation
- Define a clear, testable contract for the mobile filters drawer, header controls, pill density, and safe-area handling to guide upcoming UI work. 
- Capture the current implementation points (HTML IDs, JS toggles, and CSS sizing rules) so changes can be scoped safely without refactoring unrelated code.

### Description
- Added a new documentation file `docs/mobile-layout-contract.md` that specifies required behavior for open/close, backdrop, focus trapping, scroll lock, internal scrolling, header layout, pill padding, and safe-area rules. 
- Identified the current implementation anchors including toggle and controls: `#mobileFiltersToggle`, `#practiceSidebar`, `.practice-sidebar-sheet`, `#mobileFiltersApply`, `#mobileFiltersClose`, `#mobileFiltersBackdrop`, `#mobileClearFocus`, `#mobileClearFilters`, `#btnFiltersClear`, `#langEn`, and `#langCy`. 
- Pointed out the JS control that shows/hides the drawer as `setMobileFiltersOpen()` (used by the click handler on `#mobileFiltersToggle` and by `#mobileFiltersApply`, `#mobileFiltersClose`, and `#mobileFiltersBackdrop`). 
- Listed the CSS selectors that size/position/overflow the drawer as `#practiceSidebar`, `#practiceSidebar.is-open`, `.mobile-filters-backdrop`, `.practice-sidebar-sheet`, `#practiceSidebar.is-open .practice-sidebar-sheet`, `body.mobile-filters-open`, `.mobile-filters-body`, and `.mobile-filters-actions`; noted that safe-area insets are used via `env(safe-area-inset-*)` and that the drawer height uses `calc(var(--viewport-height, 100svh) - var(--mobile-bar-total))`. 
- Before/after behavior: before — mobile drawer behavior is implemented in JS/CSS as documented; after — no UI or JS changes were made, only the documentation file was added. 
- How to test (manual): open `docs/mobile-layout-contract.md` to review the contract, then verify the referenced selectors exist in `nav/navbar.html`, `index.html`, `js/mutation-trainer.js`, and `css/styles.css` as described (e.g., confirm `#mobileFiltersToggle` in `nav/navbar.html` and `#practiceSidebar` with `.practice-sidebar-sheet` in `index.html`).

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d2d972208324b9cfdaf7482dc664)