### PR TITLE
Add pill tokens and apply pill styling across filters and toggles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -79,6 +79,22 @@ body{
   --chip-bd:rgba(4,120,87,0.22);
   --chip-fg:#065f46;
 
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --shadow-soft: 0 10px 30px rgba(0,0,0,.08);
+  --border-soft: 1px solid rgba(0,0,0,.10);
+
+  /* Pill sizing (OLD design density) */
+  --pill-px: 10px;
+  --pill-py: 6px;
+  --pill-gap: 8px;
+  --pill-font: 14px;
+  --pill-line: 1.1;
+
+  /* Layout heights */
+  --header-h: 56px;
+  --footer-h: 64px;
+
   --focus:rgba(4,120,87,0.35);
 
   --tap-target-min-height: 2.5rem;
@@ -337,9 +353,8 @@ body{
 .chip{
   display:inline-flex;
   align-items:center;
-  border-radius:999px;
-  padding:4px 10px;
-  font-size:0.75rem;
+  border-radius:var(--radius-sm);
+  font-size:calc(var(--pill-font) - 2px);
   font-weight:600;
   letter-spacing:0.02em;
   border:1px solid var(--chip-bd);
@@ -353,15 +368,20 @@ body{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:.35rem;
-  border-radius:0.85rem;
-  padding:var(--tap-target-pad-y) var(--tap-target-pad-x);
+  gap:var(--pill-gap);
+  border-radius:var(--radius-md);
+  padding:var(--pill-py) var(--pill-px);
   min-width:2.5rem;
   min-height:var(--tap-target-min-height);
   font-weight:650;
-  font-size:10px;
-  border:1px solid rgba(148,163,184,.28);
-  background:rgba(255,255,255,.82);
+  font-size:var(--pill-font);
+  line-height:var(--pill-line);
+  border:var(--border-soft);
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--primary-from) 12%, #fff) 0%,
+    color-mix(in srgb, var(--gold) 10%, #fff) 55%,
+    color-mix(in srgb, var(--cymru-red) 8%, #fff) 100%
+  );
   cursor:pointer;
   transition: transform .08s ease, box-shadow .12s ease, background .12s ease, border-color .12s ease;
   max-width:100%;
@@ -466,23 +486,25 @@ body{
 .preset-btn {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 0.25rem;
-  padding: var(--tap-target-pad-y) var(--tap-target-pad-x);
+  padding: var(--pill-py) var(--pill-px);
   min-height: var(--tap-target-min-height);
-  border-radius: 0.75rem;
-  background: #ffffff;
-  border: 1px solid rgba(148,163,184,0.35);
-  box-shadow: 0 10px 20px rgba(15,23,42,0.08), inset 0 1px 0 rgba(255,255,255,0.9);
-  transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
+  border-radius: var(--radius-md);
+  border: var(--border-soft);
+  box-shadow: 0 6px 16px rgba(15,23,42,0.08), inset 0 1px 0 rgba(255,255,255,0.9);
+  transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease, filter .15s ease;
   position: relative;
   max-width: 100%;
   white-space: normal;
+  text-align: left;
 }
 
 .preset-btn:hover {
   transform: translateY(-1px);
   border-color: rgba(148,163,184,0.5);
-  box-shadow: 0 14px 26px rgba(15,23,42,0.12);
+  box-shadow: var(--shadow-soft);
+  filter: saturate(1.03) brightness(1.01);
 }
 
 .preset-btn[aria-pressed="true"],
@@ -539,10 +561,10 @@ body{
   color: var(--text);
 }
 .pill:hover{
-  background: rgba(255,255,255,0.96);
-  box-shadow: 0 10px 18px rgba(2,6,23,0.07);
+  box-shadow: var(--shadow-soft);
+  filter: saturate(1.03) brightness(1.01);
 }
-.pill:active{ transform: translateY(0px); box-shadow: 0 6px 12px rgba(2,6,23,0.05); }
+.pill:active{ transform: translateY(0px); box-shadow: 0 6px 12px rgba(2,6,23,0.06); }
 
 .pill-on{
   background: rgba(16,185,129,.28);
@@ -635,26 +657,31 @@ body{
 
 /* ---------- Language toggle ---------- */
 .header-actions-lang .btn{
-  border: 1px solid rgba(15,23,42,0.16);
-  background: rgba(255,255,255,0.9);
+  border: var(--border-soft);
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--primary-from) 12%, #fff) 0%,
+    color-mix(in srgb, var(--gold) 10%, #fff) 55%,
+    color-mix(in srgb, var(--cymru-red) 8%, #fff) 100%
+  );
   color: rgba(15,23,42,0.9);
-  font-size: 0.85rem;
+  font-size: var(--pill-font);
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   min-width: 2.6rem;
   min-height: 2.3rem;
-  padding: 0 0.75rem;
-  border-radius: 999px;
+  padding: var(--pill-py) var(--pill-px);
+  border-radius: var(--radius-md);
+  line-height: var(--pill-line);
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
 .header-actions-lang .btn:hover{
-  background: rgba(255,255,255,1);
   border-color: rgba(6,78,59,0.35);
   transform: translateY(-1px);
-  box-shadow: 0 8px 16px rgba(2,6,23,0.08);
+  box-shadow: var(--shadow-soft);
+  filter: saturate(1.03) brightness(1.01);
 }
 .header-actions-lang .btn.is-active{
   color: #fff;

--- a/js/card.js
+++ b/js/card.js
@@ -380,7 +380,7 @@ export function renderPractice() {
   const addChip = (text, onClear) => {
     const c = document.createElement("button");
     c.type = "button";
-    c.className = "chip";
+    c.className = "chip pill";
     c.innerHTML = `<span>${esc(text)}</span>`;
     if (onClear) {
       const x = document.createElement("span");

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -521,7 +521,7 @@ function wirePresetUi() {
       const p = PRESET_DEFS[id];
       const btn = document.createElement("button");
       btn.type = "button";
-      btn.className = `preset-btn ${state.activePreset === id ? "preset-on" : ""}`;
+      btn.className = `preset-btn pill ${state.activePreset === id ? "preset-on" : ""}`;
       btn.dataset.preset = id;
       btn.setAttribute("aria-pressed", state.activePreset === id ? "true" : "false");
 

--- a/nav/navbar.html
+++ b/nav/navbar.html
@@ -16,8 +16,8 @@
 
       <div class="header-actions grid grid-cols-2 gap-2 w-full sm:flex sm:flex-nowrap sm:items-center sm:justify-start md:justify-end md:gap-3">
         <div class="header-actions-lang flex items-center">
-          <button id="langEn" class="btn header-btn" data-lang="en" data-lang-toggle="true" type="button">EN</button>
-          <button id="langCy" class="btn header-btn" data-lang="cy" data-lang-toggle="true" type="button">CY</button>
+          <button id="langEn" class="btn header-btn pill" data-lang="en" data-lang-toggle="true" type="button">EN</button>
+          <button id="langCy" class="btn header-btn pill" data-lang="cy" data-lang-toggle="true" type="button">CY</button>
         </div>
         <div class="header-actions-controls flex items-center justify-end gap-2 sm:gap-2">
           <nav class="hidden md:flex items-center gap-2" aria-label="Primary">


### PR DESCRIPTION
### Motivation

- Introduce CSS tokens for pill sizing, radii and soft shadows/borders so pill-like controls can be sized consistently and themed from existing palette variables.
- Move chips/pills/preset/language toggles onto a single pill utility to make visual density and hover/active behaviour consistent.

### Description

- Added new design tokens to `:root` in `css/styles.css`: `--radius-sm`, `--radius-md`, `--shadow-soft`, `--border-soft`, `--pill-px`, `--pill-py`, `--pill-gap`, `--pill-font`, `--pill-line`, `--header-h`, and `--footer-h`.
- Updated `.chip` and `.pill` rules in `css/styles.css` to consume the new tokens and to use a subtle gradient background reusing existing palette variables (`--primary-from`, `--gold`, `--cymru-red`) and `--border-soft`/`--shadow-soft` for borders and hover shadow.
- Adjusted `.preset-btn` and `.header-actions-lang .btn` styles to align with pill sizing and radii tokens and to use subtle shadows/filters on hover.
- Applied the `pill` utility class to runtime-generated and static elements by updating `js/mutation-trainer.js` (preset buttons), `js/card.js` (filter summary chips), and `nav/navbar.html` (language toggle buttons) so only pills/buttons receive the new pill styling.

### Testing

- Launched a local static server with `python -m http.server 8000` and ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot, which completed successfully and produced `artifacts/pill-updates.png`.
- No automated unit tests exist for these UI-only changes; visual verification was performed via the screenshot capture and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d434553483248ca980af53b528c6)