### PR TITLE
Add Shoelace mobile filters drawer shell

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -90,6 +90,7 @@ body{
   --pill-gap: 8px;
   --pill-font: 14px;
   --pill-line: 1.1;
+  --drawer-pad: 1rem;
 
   /* Layout heights */
   --header-h: 56px;
@@ -100,6 +101,44 @@ body{
   --tap-target-min-height: 2.5rem;
   --tap-target-pad-y: 0.45rem;
   --tap-target-pad-x: 0.75rem;
+}
+
+/* ---------- Mobile filters drawer (Shoelace) ---------- */
+sl-drawer#filtersDrawer::part(panel){
+  border-radius: 1.5rem 1.5rem 0 0;
+  box-shadow: 0 -18px 40px rgba(15,23,42,0.18);
+}
+sl-drawer#filtersDrawer::part(body){
+  padding: var(--drawer-pad);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: min(80vh, 34rem);
+  overflow: hidden;
+}
+.drawer-header{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+.drawer-title{
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+}
+.drawer-body{
+  flex: 1 1 auto;
+  min-height: 3rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  -webkit-overflow-scrolling: touch;
+}
+.drawer-footer{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
 }
 
 /* ---------- Page background ---------- */

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>Welsh Mutation Trainer</title>
 
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.14.0/cdn/themes/light.css">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.14.0/cdn/shoelace.js"></script>
   <link rel="stylesheet" href="css/styles.css" />
 
   <style>
@@ -529,6 +531,20 @@
       </div>
     </footer>
   </div>
+
+  <sl-drawer id="filtersDrawer" placement="bottom" label="Filters">
+    <div class="drawer-header">
+      <div class="drawer-title">Filters</div>
+      <button type="button" class="pill drawer-close" data-close-drawer>Close</button>
+    </div>
+    <div id="filtersDrawerBody" class="drawer-body">
+      <!-- placeholder only for now -->
+    </div>
+    <div class="drawer-footer">
+      <button type="button" class="pill pill-primary" data-apply-filters>Apply</button>
+      <button type="button" class="pill" data-clear-filters>Clear</button>
+    </div>
+  </sl-drawer>
 <script type="module" src="js/mutation-trainer.js"></script>
 
 </body>

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1342,6 +1342,8 @@ function wireUi() {
 
   initCardUi();
 
+  const filtersDrawer = $("#filtersDrawer");
+  const mobileFiltersToggle = $("#mobileFiltersToggle");
   const getMobileFiltersToggles = () => [$("#mobileFiltersToggle")].filter(Boolean);
   const setMobileFiltersOpen = (isOpen) => {
     const sidebar = $("#practiceSidebar");
@@ -1355,8 +1357,19 @@ function wireUi() {
   document.addEventListener("click", (event) => {
     const toggle = event.target?.closest?.("#mobileFiltersToggle");
     if (!toggle) return;
+    if (filtersDrawer) {
+      filtersDrawer.show();
+      toggle.setAttribute("aria-expanded", "true");
+      return;
+    }
     const isOpen = $("#practiceSidebar")?.classList.contains("is-open");
     setMobileFiltersOpen(!isOpen);
+  });
+  filtersDrawer?.addEventListener("sl-after-hide", () => {
+    mobileFiltersToggle?.setAttribute("aria-expanded", "false");
+  });
+  $("[data-close-drawer]")?.addEventListener("click", () => {
+    filtersDrawer?.hide();
   });
 
   applyOnboardDismissedState();


### PR DESCRIPTION
### Motivation
- Provide a proper overlay bottom-drawer for mobile Filters to satisfy the overlay/drawer UX requirements and avoid moving existing in-flow filter controls.
- Use a pinned Shoelace release to get an accessible drawer implementation (backdrop, Escape, focus trapping) without reimplementing complex behaviour.

### Description
- Added Shoelace light theme CSS and Shoelace module include (pinned to `@shoelace-style/shoelace@2.14.0`) in `index.html` head via the CDN links.  
- Inserted an empty Shoelace drawer shell near the end of `index.html` body: `<sl-drawer id="filtersDrawer" placement="bottom" label="Filters">...</sl-drawer>` and internal elements `#filtersDrawerBody`, `.drawer-header`, `.drawer-title`, `.drawer-body`, `.drawer-footer`, `[data-close-drawer]`, `[data-apply-filters]`, and `[data-clear-filters]`.  
- Styled the drawer using CSS parts and tokens in `css/styles.css` with `sl-drawer#filtersDrawer::part(panel)` and `sl-drawer#filtersDrawer::part(body)` plus `.drawer-*` rules to provide rounded top corners, soft shadow, controlled padding, and an internally scrollable body.  
- Wired minimal JS in `js/mutation-trainer.js` so the existing header/mobile Filters toggle opens the Shoelace drawer (`filtersDrawer.show()`), the Close pill calls `filtersDrawer.hide()`, and the drawer `sl-after-hide` listener updates `#mobileFiltersToggle` `aria-expanded`.  
- Files edited: `index.html`, `css/styles.css`, `js/mutation-trainer.js` and selectors/IDs touched: `#filtersDrawer`, `#filtersDrawerBody`, `.drawer-header`, `.drawer-title`, `.drawer-body`, `.drawer-footer`, `[data-close-drawer]`, `[data-apply-filters]`, `[data-clear-filters]`, `#mobileFiltersToggle`, `sl-drawer#filtersDrawer::part(panel)`, `sl-drawer#filtersDrawer::part(body)`.

### Testing
- Started a local dev server with `python -m http.server 8000`, which launched successfully and served the site.  
- Attempted an automated Playwright script to open the site at a mobile viewport and click `#mobileFiltersToggle` to verify the drawer, but the Playwright run timed out and failed to produce a screenshot.  
- Git operations and a commit were performed to record the change (`git commit` succeeded); no unit tests or linters were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973eb5f75b08324a75f56b544417d31)