### PR TITLE
Move filters into mobile drawer and enable drawer scrolling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -113,7 +113,7 @@ sl-drawer#filtersDrawer::part(body){
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  max-height: min(80vh, 34rem);
+  max-height: 100dvh;
   overflow: hidden;
 }
 .drawer-header{
@@ -130,7 +130,8 @@ sl-drawer#filtersDrawer::part(body){
 .drawer-body{
   flex: 1 1 auto;
   min-height: 3rem;
-  overflow-y: auto;
+  max-height: calc(100dvh - 160px);
+  overflow: auto;
   padding-right: 0.25rem;
   -webkit-overflow-scrolling: touch;
 }

--- a/index.html
+++ b/index.html
@@ -190,82 +190,6 @@
 
         <!-- Right: filters + session -->
         <div id="practiceSidebar" class="practice-sidebar md:col-span-1 flex flex-col gap-4">
-          <button id="mobileFiltersBackdrop" class="mobile-filters-backdrop md:hidden" type="button" aria-label="Close filters"></button>
-          <div class="practice-sidebar-sheet flex flex-col gap-4">
-            <div class="mobile-filters-header md:hidden">
-              <div class="mobile-filters-handle" aria-hidden="true"></div>
-              <button id="mobileFiltersClose" class="btn btn-ghost btn-compact mobile-filters-close" type="button" aria-label="Close filters">
-                <span aria-hidden="true">✕</span>
-                <span class="mobile-filters-close-text">Close</span>
-              </button>
-              <span id="mobileFiltersTitle" class="mobile-filters-title text-sm font-semibold">Filters</span>
-              <button id="mobileFiltersApply" class="btn btn-primary btn-compact mobile-filters-apply" type="button">Apply</button>
-            </div>
-            <div class="mobile-filters-body">
-              <div id="filtersPanel" class="panel rounded-2xl p-4">
-                <div class="flex flex-col gap-3">
-                  <details id="quickPacksSection" open>
-                    <summary id="quickPacksSummary" class="cursor-pointer text-sm font-semibold select-none">Quick packs</summary>
-                    <div class="mt-3">
-                      <div id="focusHelper" class="text-xs text-slate-500 mb-3"></div>
-                      <div id="presetsHelper" class="text-xs text-slate-500 mb-2"></div>
-                      <div id="presetBtns" class="grid grid-cols-2 gap-2"></div>
-                      <!-- Focus indicator shows which preset/pack is active (set by JS) -->
-                      <div id="focusIndicator" class="text-xs font-medium text-slate-600 hidden mt-1"></div>
-                    </div>
-                  </details>
-
-                  <details id="coreFiltersSection" open>
-                    <summary id="coreFiltersSummary" class="cursor-pointer text-sm font-semibold select-none">Core filters</summary>
-                    <div class="filters-section-body">
-                      <div id="coreFiltersHelper" class="text-xs text-slate-500 mb-2"></div>
-                      <div id="basicFocus">
-                        <div class="grid grid-cols-1 gap-2 text-sm">
-                          <div id="familyCol">
-                            <div id="rulefamilyTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Mutation type</div>
-                            <div id="familyBtns" class="flex flex-wrap gap-1"></div>
-                          </div>
-                          <div class="col-span-1">
-                            <div id="categoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Categories</div>
-                            <div id="categoryPills" class="flex flex-wrap gap-1 items-center">
-                              <div id="coreCategoryChips" class="pill-group"></div>
-                              <button id="moreFiltersToggle" class="pill pill-more" type="button" aria-expanded="false" aria-controls="moreFiltersInline">
-                                <span class="pill-label">More filters</span>
-                                <span class="pill-icon" aria-hidden="true">▾</span>
-                              </button>
-                              <div id="moreFiltersInline" class="more-filters-inline flex flex-wrap gap-1 items-center">
-                                <div id="extraCategoryChips" class="pill-group is-hidden"></div>
-                                <div id="allCategoryChips" class="pill-group is-hidden"></div>
-                                <div id="moreFiltersPanel" class="filters-extra is-hidden">
-                                  <div class="mt-2">
-                                    <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
-                                    <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
-                                  </div>
-                                  <div class="mt-3 flex flex-wrap gap-1"></div>
-                                </div>
-                              </div>
-                              <button id="btnFiltersClear" class="pill pill-clear" type="button">
-                                <span class="pill-label">Clear filters</span>
-                                <span class="pill-icon" aria-hidden="true">×</span>
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </details>
-
-                  <section id="moreFiltersSection" class="hidden"></section>
-                </div>
-              </div>
-            </div>
-
-            <div class="mobile-filters-actions md:hidden flex flex-wrap gap-2">
-              <button id="mobileClearFocus" class="btn btn-ghost flex-1" type="button">Clear focus</button>
-              <button id="mobileClearFilters" class="btn btn-ghost flex-1" type="button">Clear filters</button>
-            </div>
-          </div>
-
             <!-- Session stats hidden under details -->
             <details id="statsDetails" class="panel rounded-2xl p-4 hidden md:block">
               <summary id="moreStatsSummary" class="cursor-pointer text-sm font-medium select-none">More stats</summary>
@@ -534,15 +458,74 @@
 
   <sl-drawer id="filtersDrawer" placement="bottom" label="Filters">
     <div class="drawer-header">
-      <div class="drawer-title">Filters</div>
-      <button type="button" class="pill drawer-close" data-close-drawer>Close</button>
+      <button id="mobileFiltersClose" class="btn btn-ghost btn-compact mobile-filters-close" type="button" aria-label="Close filters" data-close-drawer>
+        <span aria-hidden="true">✕</span>
+        <span class="mobile-filters-close-text">Close</span>
+      </button>
+      <div class="drawer-title" id="mobileFiltersTitle">Filters</div>
+      <button id="mobileFiltersApply" class="btn btn-primary btn-compact mobile-filters-apply" type="button" data-close-drawer>Apply</button>
     </div>
     <div id="filtersDrawerBody" class="drawer-body">
-      <!-- placeholder only for now -->
+      <div id="filtersPanel" class="panel rounded-2xl p-4">
+        <div class="flex flex-col gap-3">
+          <details id="quickPacksSection" open>
+            <summary id="quickPacksSummary" class="cursor-pointer text-sm font-semibold select-none">Quick packs</summary>
+            <div class="mt-3">
+              <div id="focusHelper" class="text-xs text-slate-500 mb-3"></div>
+              <div id="presetsHelper" class="text-xs text-slate-500 mb-2"></div>
+              <div id="presetBtns" class="grid grid-cols-2 gap-2"></div>
+              <!-- Focus indicator shows which preset/pack is active (set by JS) -->
+              <div id="focusIndicator" class="text-xs font-medium text-slate-600 hidden mt-1"></div>
+            </div>
+          </details>
+
+          <details id="coreFiltersSection" open>
+            <summary id="coreFiltersSummary" class="cursor-pointer text-sm font-semibold select-none">Core filters</summary>
+            <div class="filters-section-body">
+              <div id="coreFiltersHelper" class="text-xs text-slate-500 mb-2"></div>
+              <div id="basicFocus">
+                <div class="grid grid-cols-1 gap-2 text-sm">
+                  <div id="familyCol">
+                    <div id="rulefamilyTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Mutation type</div>
+                    <div id="familyBtns" class="flex flex-wrap gap-1"></div>
+                  </div>
+                  <div class="col-span-1">
+                    <div id="categoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Categories</div>
+                    <div id="categoryPills" class="flex flex-wrap gap-1 items-center">
+                      <div id="coreCategoryChips" class="pill-group"></div>
+                      <button id="moreFiltersToggle" class="pill pill-more" type="button" aria-expanded="false" aria-controls="moreFiltersInline">
+                        <span class="pill-label">More filters</span>
+                        <span class="pill-icon" aria-hidden="true">▾</span>
+                      </button>
+                      <div id="moreFiltersInline" class="more-filters-inline flex flex-wrap gap-1 items-center">
+                        <div id="extraCategoryChips" class="pill-group is-hidden"></div>
+                        <div id="allCategoryChips" class="pill-group is-hidden"></div>
+                        <div id="moreFiltersPanel" class="filters-extra is-hidden">
+                          <div class="mt-2">
+                            <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
+                            <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
+                          </div>
+                          <div class="mt-3 flex flex-wrap gap-1"></div>
+                        </div>
+                      </div>
+                      <button id="btnFiltersClear" class="pill pill-clear" type="button">
+                        <span class="pill-label">Clear filters</span>
+                        <span class="pill-icon" aria-hidden="true">×</span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </details>
+
+          <section id="moreFiltersSection" class="hidden"></section>
+        </div>
+      </div>
     </div>
     <div class="drawer-footer">
-      <button type="button" class="pill pill-primary" data-apply-filters>Apply</button>
-      <button type="button" class="pill" data-clear-filters>Clear</button>
+      <button id="mobileClearFocus" class="btn btn-ghost flex-1" type="button">Clear focus</button>
+      <button id="mobileClearFilters" class="btn btn-ghost flex-1" type="button">Clear filters</button>
     </div>
   </sl-drawer>
 <script type="module" src="js/mutation-trainer.js"></script>

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1480,7 +1480,7 @@ function wireUi() {
     if (!(target instanceof HTMLElement)) return;
     const isTextField = target.matches("input, textarea, [contenteditable='true']");
     if (!isTextField) return;
-    const mobileFiltersBody = target.closest(".mobile-filters-body");
+    const mobileFiltersBody = target.closest(".mobile-filters-body, #filtersDrawerBody");
     if (!mobileFiltersBody) return;
     requestAnimationFrame(() => {
       target.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "smooth" });


### PR DESCRIPTION
### Motivation
- Make the mobile filters a true overlay drawer by relocating the existing filters markup into the Shoelace drawer body while preserving all original IDs and JS bindings.
- Ensure the drawer body is scrollable using viewport-based sizing so long filter content scrolls internally on mobile.

### Description
- Moved the full filters block from the sidebar into the drawer body `#filtersDrawerBody` and placed header/footer controls into the drawer header/footer in `index.html` (files edited: `index.html`).
- Updated drawer CSS in `css/styles.css` to use viewport-based sizes: `sl-drawer::part(body)` now uses `max-height: 100dvh` and `.drawer-body` uses `max-height: calc(100dvh - 160px); overflow: auto;` to enable internal scrolling.
- Updated focus/scroll logic in `js/mutation-trainer.js` so focus-in handling recognizes the new container by matching `.mobile-filters-body, #filtersDrawerBody` so inputs inside the drawer scroll into view.
- Files changed: `index.html`, `css/styles.css`, `js/mutation-trainer.js`.
- Key selectors / IDs preserved and relocated (verified): `#filtersDrawerBody`, `#filtersPanel`, `#quickPacksSection`, `#coreFiltersSection`, `#moreFiltersToggle`, `#triggerFilter`, `#btnFiltersClear`, `#moreFiltersSection`, `#mobileFiltersClose`, `#mobileFiltersTitle`, `#mobileFiltersApply`, `#mobileClearFocus`, `#mobileClearFilters`.

### Testing
- Started a dev server with `python -m http.server 8000` which served the modified `index.html` successfully.
- Verified the served HTML contains the drawer markup via `curl` / `rg` (found `sl-drawer` and `#filtersDrawer`).
- Ran Playwright automation attempts to open the drawer; attempts to programmatically click the mobile toggle or await the drawer opening timed out / failed in headless runs (likely due to timing / web-component initialization), so interactive open via automated Playwright did not succeed.
- Captured a headless mobile-page screenshot automatically (`artifacts/mobile-page.png`) confirming the page served; DOM checks using Playwright evaluation reported `filtersDrawer exists False` in that headless context but `curl` checks show the markup is present in the served HTML.
- Result summary: static markup and CSS changes verified via served HTML and CSS inspection (success); automated UI open via Playwright timed out (failed) so I recommend a quick manual smoke test on a mobile viewport to confirm runtime drawer open/close/focus and that each filter control functions end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973edf16e788324ba10558176698e57)