### PR TITLE
Remove legacy mobile filter drawer mechanics

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1890,96 +1890,12 @@ body.scroll-locked{
   #practiceCard{
     min-height: 0;
   }
-  #practiceSidebar{
-    position: fixed;
-    inset: 0;
-    display: none;
-    align-items: stretch;
-    justify-content: flex-start;
-    padding: 0;
-    z-index: 10040;
-    max-width: 100vw;
-    height: calc(var(--viewport-height, 100svh) - var(--mobile-bar-total));
-    max-height: calc(var(--viewport-height, 100lvh) - var(--mobile-bar-total));
-  }
-  #practiceSidebar.is-open{
-    display: flex;
-  }
-  .mobile-filters-backdrop{
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(15,23,42,0.45);
-    border: 0;
-    padding: 0;
-    cursor: pointer;
-  }
-  .practice-sidebar-sheet{
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1;
-    width: 100%;
-    max-width: 100%;
-    height: calc(var(--viewport-height, 100svh) - var(--mobile-bar-total));
-    max-height: 100%;
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
-    display: flex;
-    flex-direction: column;
-    background: #f8fafc;
-    border-radius: 1.5rem 1.5rem 0 0;
-    box-shadow: 0 -16px 30px rgba(15,23,42,0.18);
-    opacity: 0;
-    transition: opacity 0.2s ease, max-height 0.2s ease;
-  }
-  #practiceSidebar.is-open .practice-sidebar-sheet{
-    opacity: 1;
-  }
-  body.mobile-filters-open #siteHeader{
-    display: none;
-  }
-  body.mobile-filters-open #main{
-    padding-top: 0;
-  }
-  body.mobile-filters-open{
-    overflow: hidden;
-  }
-  .mobile-filters-header{
-    position: sticky;
-    top: 0;
-    background: #f8fafc;
-    border-bottom: 1px solid rgba(15,23,42,0.12);
-    box-shadow: 0 1px 0 rgba(15,23,42,0.04);
-    padding: 1.4rem 1rem 0.75rem;
-    z-index: 3;
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
-    gap: 0.5rem;
-  }
-  .mobile-filters-handle{
-    position: absolute;
-    top: 0.5rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 2.6rem;
-    height: 0.3rem;
-    border-radius: 999px;
-    background: rgba(148,163,184,0.7);
-  }
   .mobile-filters-close{
     gap: .35rem;
     justify-self: start;
   }
   .mobile-filters-close-text{
     font-size: .75rem;
-  }
-  .mobile-filters-title{
-    justify-self: center;
-    text-align: center;
   }
   .mobile-filters-apply{
     justify-self: end;
@@ -1989,18 +1905,6 @@ body.scroll-locked{
     border-radius: 0.6rem;
     line-height: 1;
   }
-  .mobile-filters-body{
-    padding: 0 1rem calc(1.5rem + var(--keyboard-offset));
-    overflow-y: auto;
-    flex: 1 1 auto;
-    min-height: 0;
-    overscroll-behavior: contain;
-    scroll-padding-bottom: calc(1.5rem + var(--keyboard-offset));
-    -webkit-overflow-scrolling: touch;
-  }
-  .mobile-filters-body:focus-within{
-    scroll-behavior: smooth;
-  }
   #filtersPanel{
     width: 100%;
     background: transparent;
@@ -2008,12 +1912,6 @@ body.scroll-locked{
     box-shadow: none;
     border-radius: 0;
     padding: 0;
-  }
-  .mobile-filters-actions{
-    flex: 0 0 auto;
-    padding: 0.85rem 1rem calc(1rem + env(safe-area-inset-bottom));
-    background: #f8fafc;
-    border-top: 1px solid rgba(15,23,42,0.12);
   }
   .practice-filter-summary{
     display: none;

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
         </div>
 
         <!-- Right: filters + session -->
-        <div id="practiceSidebar" class="practice-sidebar md:col-span-1 flex flex-col gap-4">
+        <div class="md:col-span-1 flex flex-col gap-4">
             <!-- Session stats hidden under details -->
             <details id="statsDetails" class="panel rounded-2xl p-4 hidden md:block">
               <summary id="moreStatsSummary" class="cursor-pointer text-sm font-medium select-none">More stats</summary>

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1344,32 +1344,19 @@ function wireUi() {
 
   const filtersDrawer = $("#filtersDrawer");
   const mobileFiltersToggle = $("#mobileFiltersToggle");
-  const getMobileFiltersToggles = () => [$("#mobileFiltersToggle")].filter(Boolean);
-  const setMobileFiltersOpen = (isOpen) => {
-    const sidebar = $("#practiceSidebar");
-    if (!sidebar) return;
-    sidebar.classList.toggle("is-open", isOpen);
-    document.body.classList.toggle("mobile-filters-open", isOpen);
-    getMobileFiltersToggles().forEach((toggle) => {
-      toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
-    });
-  };
   document.addEventListener("click", (event) => {
     const toggle = event.target?.closest?.("#mobileFiltersToggle");
     if (!toggle) return;
-    if (filtersDrawer) {
-      filtersDrawer.show();
-      toggle.setAttribute("aria-expanded", "true");
-      return;
-    }
-    const isOpen = $("#practiceSidebar")?.classList.contains("is-open");
-    setMobileFiltersOpen(!isOpen);
+    filtersDrawer?.show();
+  });
+  filtersDrawer?.addEventListener("sl-after-show", () => {
+    mobileFiltersToggle?.setAttribute("aria-expanded", "true");
   });
   filtersDrawer?.addEventListener("sl-after-hide", () => {
     mobileFiltersToggle?.setAttribute("aria-expanded", "false");
   });
-  $("[data-close-drawer]")?.addEventListener("click", () => {
-    filtersDrawer?.hide();
+  $$("[data-close-drawer]").forEach((btn) => {
+    btn.addEventListener("click", () => filtersDrawer?.hide());
   });
 
   applyOnboardDismissedState();
@@ -1464,14 +1451,11 @@ function wireUi() {
   $("#mbSkip")?.addEventListener("click", () => $("#btnSkip")?.click());
   $("#mbNext")?.addEventListener("click", () => nextCard(1));
 
-  $("#mobileFiltersApply")?.addEventListener("click", () => setMobileFiltersOpen(false));
-  $("#mobileFiltersClose")?.addEventListener("click", () => setMobileFiltersOpen(false));
-  $("#mobileFiltersBackdrop")?.addEventListener("click", () => setMobileFiltersOpen(false));
   $("#mobileClearFocus")?.addEventListener("click", () => clearFocusAndRender());
   $("#mobileClearFilters")?.addEventListener("click", () => clearFiltersAndRender());
 
   window.addEventListener("resize", () => {
-    if (window.innerWidth >= 768) setMobileFiltersOpen(false);
+    if (window.innerWidth >= 768) filtersDrawer?.hide();
   });
   const scheduleViewportUpdate = () => requestAnimationFrame(updateViewportMetrics);
   const handleFocusIn = (event) => {
@@ -1480,7 +1464,7 @@ function wireUi() {
     if (!(target instanceof HTMLElement)) return;
     const isTextField = target.matches("input, textarea, [contenteditable='true']");
     if (!isTextField) return;
-    const mobileFiltersBody = target.closest(".mobile-filters-body, #filtersDrawerBody");
+    const mobileFiltersBody = target.closest("#filtersDrawerBody");
     if (!mobileFiltersBody) return;
     requestAnimationFrame(() => {
       target.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "smooth" });

--- a/nav/navbar.html
+++ b/nav/navbar.html
@@ -23,7 +23,7 @@
           <nav class="hidden md:flex items-center gap-2" aria-label="Primary">
           </nav>
           <div class="hidden md:block h-6 w-px bg-slate-200/80"></div>
-          <button id="mobileFiltersToggle" class="btn btn-ghost btn-mobile-filters header-btn md:hidden" type="button" aria-controls="practiceSidebar" aria-expanded="false">
+          <button id="mobileFiltersToggle" class="btn btn-ghost btn-mobile-filters header-btn md:hidden" type="button" aria-controls="filtersDrawer" aria-expanded="false">
             <span class="btn-icon" aria-hidden="true">🎛️</span>
             <span class="btn-label">Filters</span>
           </button>


### PR DESCRIPTION
### Motivation
- Remove old CSS/JS hacks that manually positioned/toggled a fixed mobile sidebar and instead rely on the Shoelace `<sl-drawer>` component for mobile filter UX to simplify code and avoid duplicate open/close mechanics.
- Ensure the mobile filter button and close elements use the Shoelace drawer API while preserving existing filter logic and mobile focus/scroll behavior.

### Description
- Deleted legacy CSS rules that managed the old drawer container and its hacks (removed `#practiceSidebar`, `.practice-sidebar-sheet`, `.mobile-filters-backdrop`, `.mobile-filters-body`, `body.mobile-filters-open`, and `.is-open`) from `css/styles.css`.
- Removed the manual open/close toggle code (`setMobileFiltersOpen` and `.is-open` toggling) and replaced the click handler to call the Shoelace drawer `show()` API; added `sl-after-show`/`sl-after-hide` listeners to update `aria-expanded`, and routed all close buttons to `filtersDrawer.hide()` in `js/mutation-trainer.js`.
- Removed the `id="practiceSidebar"` from the sidebar container in `index.html` and kept the Shoelace `<sl-drawer id="filtersDrawer">` markup for the mobile filters content.
- Updated the mobile filters toggle in `nav/navbar.html` to use `aria-controls="filtersDrawer"` so the button points at the Shoelace drawer.

### Testing
- Confirmed old selectors are gone with ripgrep: ran `rg -n "practiceSidebar|practice-sidebar-sheet|mobile-filters-open|mobile-filters-backdrop|mobile-filters-body|\bis-open\b" -S index.html css styles/*.css js nav || true` and observed no matches (clean).
- Checked `index.html` contains the Shoelace drawer markup by inspecting the file served by a local HTTP server (verified `<sl-drawer id="filtersDrawer">` is present), and verified by code inspection that `#mobileFiltersToggle` now calls `filtersDrawer.show()` and that close handlers call `filtersDrawer.hide()` and `sl-after-show/sl-after-hide` update `aria-expanded` (succeeded).
- Attempted an automated end-to-end smoke test using Playwright to click `#mobileFiltersToggle` and wait for `sl-drawer#filtersDrawer[open]`, but the headless/CI environment timed out while locating the element (timing/hosting issue), so the runtime click assertion did not complete; the code-level wiring remains in place and should work in normal browser runtime.
- All changes were committed; files edited: `css/styles.css`, `js/mutation-trainer.js`, `index.html`, `nav/navbar.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f19df92c83249dc1dd0e20450a14)