### PR TITLE
Restore desktop filters and implement mobile header grid layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -286,6 +286,9 @@ body{
   min-width: 0;
   flex: 0 1 auto;
 }
+.header-actions-controls{
+  min-width: 0;
+}
 .header-actions-lang{
   gap: 0.45rem;
 }
@@ -327,6 +330,39 @@ body{
   }
   .cymru-red-bar{
     height: 2px;
+  }
+}
+
+@media (max-width: 639px){
+  .header-actions{
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: var(--pill-gap);
+    width: 100%;
+  }
+  .header-actions-controls{
+    display: contents;
+  }
+  .header-actions-lang{
+    grid-column: 1;
+    grid-row: 1;
+    justify-self: start;
+  }
+  #mobileFiltersToggle{
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+  }
+  #onboardHelpBtn{
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-self: stretch;
+  }
+  .header-actions .header-btn,
+  #mobileFiltersToggle,
+  #onboardHelpBtn{
+    width: auto;
+    min-width: 0;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -190,6 +190,64 @@
 
         <!-- Right: filters + session -->
         <div class="md:col-span-1 flex flex-col gap-4">
+            <div id="filtersPanelHost" class="hidden md:block">
+              <div id="filtersPanel" class="panel rounded-2xl p-4">
+                <div class="flex flex-col gap-3">
+                  <details id="quickPacksSection" open>
+                    <summary id="quickPacksSummary" class="cursor-pointer text-sm font-semibold select-none">Quick packs</summary>
+                    <div class="mt-3">
+                      <div id="focusHelper" class="text-xs text-slate-500 mb-3"></div>
+                      <div id="presetsHelper" class="text-xs text-slate-500 mb-2"></div>
+                      <div id="presetBtns" class="grid grid-cols-2 gap-2"></div>
+                      <!-- Focus indicator shows which preset/pack is active (set by JS) -->
+                      <div id="focusIndicator" class="text-xs font-medium text-slate-600 hidden mt-1"></div>
+                    </div>
+                  </details>
+
+                  <details id="coreFiltersSection" open>
+                    <summary id="coreFiltersSummary" class="cursor-pointer text-sm font-semibold select-none">Core filters</summary>
+                    <div class="filters-section-body">
+                      <div id="coreFiltersHelper" class="text-xs text-slate-500 mb-2"></div>
+                      <div id="basicFocus">
+                        <div class="grid grid-cols-1 gap-2 text-sm">
+                          <div id="familyCol">
+                            <div id="rulefamilyTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Mutation type</div>
+                            <div id="familyBtns" class="flex flex-wrap gap-1"></div>
+                          </div>
+                          <div class="col-span-1">
+                            <div id="categoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Categories</div>
+                            <div id="categoryPills" class="flex flex-wrap gap-1 items-center">
+                              <div id="coreCategoryChips" class="pill-group"></div>
+                              <button id="moreFiltersToggle" class="pill pill-more" type="button" aria-expanded="false" aria-controls="moreFiltersInline">
+                                <span class="pill-label">More filters</span>
+                                <span class="pill-icon" aria-hidden="true">▾</span>
+                              </button>
+                              <div id="moreFiltersInline" class="more-filters-inline flex flex-wrap gap-1 items-center">
+                                <div id="extraCategoryChips" class="pill-group is-hidden"></div>
+                                <div id="allCategoryChips" class="pill-group is-hidden"></div>
+                                <div id="moreFiltersPanel" class="filters-extra is-hidden">
+                                  <div class="mt-2">
+                                    <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
+                                    <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
+                                  </div>
+                                  <div class="mt-3 flex flex-wrap gap-1"></div>
+                                </div>
+                              </div>
+                              <button id="btnFiltersClear" class="pill pill-clear" type="button">
+                                <span class="pill-label">Clear filters</span>
+                                <span class="pill-icon" aria-hidden="true">×</span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </details>
+
+                  <section id="moreFiltersSection" class="hidden"></section>
+                </div>
+              </div>
+            </div>
             <!-- Session stats hidden under details -->
             <details id="statsDetails" class="panel rounded-2xl p-4 hidden md:block">
               <summary id="moreStatsSummary" class="cursor-pointer text-sm font-medium select-none">More stats</summary>
@@ -465,64 +523,7 @@
       <div class="drawer-title" id="mobileFiltersTitle">Filters</div>
       <button id="mobileFiltersApply" class="btn btn-primary btn-compact mobile-filters-apply" type="button" data-close-drawer>Apply</button>
     </div>
-    <div id="filtersDrawerBody" class="drawer-body">
-      <div id="filtersPanel" class="panel rounded-2xl p-4">
-        <div class="flex flex-col gap-3">
-          <details id="quickPacksSection" open>
-            <summary id="quickPacksSummary" class="cursor-pointer text-sm font-semibold select-none">Quick packs</summary>
-            <div class="mt-3">
-              <div id="focusHelper" class="text-xs text-slate-500 mb-3"></div>
-              <div id="presetsHelper" class="text-xs text-slate-500 mb-2"></div>
-              <div id="presetBtns" class="grid grid-cols-2 gap-2"></div>
-              <!-- Focus indicator shows which preset/pack is active (set by JS) -->
-              <div id="focusIndicator" class="text-xs font-medium text-slate-600 hidden mt-1"></div>
-            </div>
-          </details>
-
-          <details id="coreFiltersSection" open>
-            <summary id="coreFiltersSummary" class="cursor-pointer text-sm font-semibold select-none">Core filters</summary>
-            <div class="filters-section-body">
-              <div id="coreFiltersHelper" class="text-xs text-slate-500 mb-2"></div>
-              <div id="basicFocus">
-                <div class="grid grid-cols-1 gap-2 text-sm">
-                  <div id="familyCol">
-                    <div id="rulefamilyTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Mutation type</div>
-                    <div id="familyBtns" class="flex flex-wrap gap-1"></div>
-                  </div>
-                  <div class="col-span-1">
-                    <div id="categoriesTitle" class="text-xs uppercase tracking-wide text-slate-500 mb-1">Categories</div>
-                    <div id="categoryPills" class="flex flex-wrap gap-1 items-center">
-                      <div id="coreCategoryChips" class="pill-group"></div>
-                      <button id="moreFiltersToggle" class="pill pill-more" type="button" aria-expanded="false" aria-controls="moreFiltersInline">
-                        <span class="pill-label">More filters</span>
-                        <span class="pill-icon" aria-hidden="true">▾</span>
-                      </button>
-                      <div id="moreFiltersInline" class="more-filters-inline flex flex-wrap gap-1 items-center">
-                        <div id="extraCategoryChips" class="pill-group is-hidden"></div>
-                        <div id="allCategoryChips" class="pill-group is-hidden"></div>
-                        <div id="moreFiltersPanel" class="filters-extra is-hidden">
-                          <div class="mt-2">
-                            <label id="triggerLabel" class="text-xs uppercase tracking-wide text-slate-500">Filter by Trigger</label>
-                            <input id="triggerFilter" class="mt-1 w-full border rounded-xl px-3 py-1.5" placeholder="e.g. i, o, dwy, tri, y (article), neu" />
-                          </div>
-                          <div class="mt-3 flex flex-wrap gap-1"></div>
-                        </div>
-                      </div>
-                      <button id="btnFiltersClear" class="pill pill-clear" type="button">
-                        <span class="pill-label">Clear filters</span>
-                        <span class="pill-icon" aria-hidden="true">×</span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </details>
-
-          <section id="moreFiltersSection" class="hidden"></section>
-        </div>
-      </div>
-    </div>
+    <div id="filtersDrawerBody" class="drawer-body"></div>
     <div class="drawer-footer">
       <button id="mobileClearFocus" class="btn btn-ghost flex-1" type="button">Clear focus</button>
       <button id="mobileClearFilters" class="btn btn-ghost flex-1" type="button">Clear filters</button>

--- a/js/mutation-trainer.js
+++ b/js/mutation-trainer.js
@@ -1344,6 +1344,18 @@ function wireUi() {
 
   const filtersDrawer = $("#filtersDrawer");
   const mobileFiltersToggle = $("#mobileFiltersToggle");
+  const filtersPanel = $("#filtersPanel");
+  const filtersPanelHost = $("#filtersPanelHost");
+  const filtersDrawerBody = $("#filtersDrawerBody");
+  const syncFiltersPanelPlacement = () => {
+    if (!filtersPanel || !filtersPanelHost || !filtersDrawerBody) return;
+    const target = window.innerWidth < 768 ? filtersDrawerBody : filtersPanelHost;
+    if (filtersPanel.parentElement !== target) {
+      target.appendChild(filtersPanel);
+    }
+  };
+  syncFiltersPanelPlacement();
+  window.addEventListener("resize", syncFiltersPanelPlacement);
   document.addEventListener("click", (event) => {
     const toggle = event.target?.closest?.("#mobileFiltersToggle");
     if (!toggle) return;


### PR DESCRIPTION
### Motivation
- Desktop users lost access to the filters panel because the UI lived only inside the mobile drawer; the change restores a deterministic desktop placement while keeping the existing mobile drawer behavior. 
- Mobile header controls must be deterministic and follow the two-row layout specification (language left + filters right on row 1, help full-width on row 2) without refactoring unrelated code or changing existing IDs.

### Description
- Restored the desktop filters host and moved the single `#filtersPanel` DOM node between sidebar and mobile drawer at runtime by adding `#filtersPanelHost` in the right column and a placement sync in `js/mutation-trainer.js` (`filtersPanel`, `filtersPanelHost`, `filtersDrawerBody`, `syncFiltersPanelPlacement`).
- Simplified the mobile drawer body to be empty in markup and rely on the runtime relocation to avoid duplicate IDs and preserve the canonical `#filtersPanel` (changed `index.html` to host `#filtersPanel` on desktop and leave `#filtersDrawerBody` empty on mobile).
- Implemented a deterministic CSS grid for header controls under 640px in `css/styles.css` by making `.header-actions` use `display: grid; grid-template-columns: 1fr auto;` and placing `.header-actions-lang`, `#mobileFiltersToggle`, and `#onboardHelpBtn` into the required grid cells; >=640px keeps the existing flex layout.
- Ensured buttons don't use fixed widths on narrow screens by resetting `width: auto; min-width: 0;` for the affected controls and added `.header-actions-controls` min-width protection.
- Files changed: `index.html`, `css/styles.css`, `js/mutation-trainer.js`; Selectors/IDs touched: `#filtersPanel`, `#filtersPanelHost`, `#filtersDrawerBody`, `.header-actions`, `.header-actions-controls`, `.header-actions-lang`, `#mobileFiltersToggle`, `#onboardHelpBtn`.

### Testing
- Launched a local server with `python -m http.server 8000` and ran a Playwright script to render `http://127.0.0.1:8000/index.html` at 375×800 and capture a screenshot, which completed successfully and produced `artifacts/header-375.png`.
- Verified the runtime placement script by resizing the browser: at widths >=768px the `#filtersPanel` is appended into `#filtersPanelHost` (desktop sidebar visible), and at widths <768px it is appended into `#filtersDrawerBody` (drawer content shown); these checks succeeded during the local run.
- Commit created: change set committed as "Fix desktop filters and mobile header grid" and there were no automated test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f3f1a3a083248930a45fb5751581)